### PR TITLE
Let bootstrap work on tables that aren't partitioned yet.

### DIFF
--- a/partitionmanager/bootstrap.py
+++ b/partitionmanager/bootstrap.py
@@ -149,11 +149,19 @@ def _generate_sql_copy_commands(
 
     range_id_string = ", ".join(map_data["range_cols"])
 
+    if len(map_data["range_cols"]) == 1:
+        range_cols_string = "RANGE"
+        max_val_string = "MAXVALUE"
+    else:
+        num_cols = len(map_data["range_cols"])
+        range_cols_string = "RANGE COLUMNS"
+        max_val_string = "(" + ", ".join(["MAXVALUE"] * num_cols) + ")"
+
     yield f"DROP TABLE IF EXISTS {new_table.name};"
     yield f"CREATE TABLE {new_table.name} LIKE {existing_table.name};"
     yield f"ALTER TABLE {new_table.name} REMOVE PARTITIONING;"
-    yield f"ALTER TABLE {new_table.name} PARTITION BY RANGE({range_id_string}) ("
-    yield f"\tPARTITION {max_val_part.name} VALUES LESS THAN MAXVALUE"
+    yield f"ALTER TABLE {new_table.name} PARTITION BY {range_cols_string} ({range_id_string}) ("
+    yield f"\tPARTITION {max_val_part.name} VALUES LESS THAN {max_val_string}"
     yield ");"
 
     for command in alter_commands_iter:

--- a/partitionmanager/bootstrap.py
+++ b/partitionmanager/bootstrap.py
@@ -16,6 +16,18 @@ RATE_UNIT = timedelta(hours=1)
 MINIMUM_FUTURE_DELTA = timedelta(hours=2)
 
 
+def _override_config_to_map_data(conf):
+    """Return an analog to get_partition_map from override data in conf"""
+    return {
+        "range_cols": [str(x) for x in conf.assume_partitioned_on],
+        "partitions": [
+            partitionmanager.types.MaxValuePartition(
+                "p_assumed", count=len(conf.assume_partitioned_on)
+            )
+        ],
+    }
+
+
 def write_state_info(conf, out_fp):
     """
     Write the state info for tables defined in conf to the provided file-like
@@ -26,11 +38,15 @@ def write_state_info(conf, out_fp):
     log.info("Writing current state information")
     state_info = {"time": conf.curtime, "tables": dict()}
     for table in conf.tables:
-        problems = pm_tap.get_table_compatibility_problems(conf.dbcmd, table)
-        if problems:
-            raise Exception("; ".join(problems))
+        map_data = None
+        if not conf.assume_partitioned_on:
+            problems = pm_tap.get_table_compatibility_problems(conf.dbcmd, table)
+            if problems:
+                raise Exception("; ".join(problems))
+            map_data = pm_tap.get_partition_map(conf.dbcmd, table)
+        else:
+            map_data = _override_config_to_map_data(conf)
 
-        map_data = pm_tap.get_partition_map(conf.dbcmd, table)
         positions = pm_tap.get_current_positions(
             conf.dbcmd, table, map_data["range_cols"]
         )
@@ -73,7 +89,7 @@ def _plan_partitions_for_time_offsets(
     for (i, offset), is_final in partitionmanager.tools.iter_show_end(
         enumerate(time_offsets)
     ):
-        increase = [x * offset / RATE_UNIT for x in rate_of_change]
+        increase = [x * (offset / RATE_UNIT) for x in rate_of_change]
         predicted_positions = [
             int(p + i) for p, i in zip(ordered_current_pos, increase)
         ]
@@ -99,6 +115,83 @@ def _plan_partitions_for_time_offsets(
 
         changes.append(part)
     return changes
+
+
+def _suffix(lines, *, indent="", mid_suffix="", final_suffix=""):
+    """ Helper that suffixes each line with either mid- or final- suffix """
+    for line, is_final in partitionmanager.tools.iter_show_end(lines):
+        if is_final:
+            yield indent + line + final_suffix
+        else:
+            yield indent + line + mid_suffix
+
+
+def _trigger_column_copies(cols):
+    """ Helper that returns lines copying each column for a trigger. """
+    for c in cols:
+        yield f"`{c}` = NEW.`{c}`"
+
+
+def _generate_sql_copy_commands(
+    existing_table, map_data, columns, new_table, alter_commands_iter
+):
+    """ Generate a series of SQL commands to start a copy of the existing_table
+    to a new_table, applying the supplied alterations before starting the
+    triggers. """
+    log = logging.getLogger(
+        f"_generate_sql_copy_commands:{existing_table.name} to {new_table.name}"
+    )
+
+    max_val_part = map_data["partitions"][-1]
+    if not isinstance(max_val_part, partitionmanager.types.MaxValuePartition):
+        log.error(f"Expected a MaxValue partition, got {max_val_part}")
+        raise Exception("Unexpected part?")
+
+    range_id_string = ", ".join(map_data["range_cols"])
+
+    yield f"DROP TABLE IF EXISTS {new_table.name};"
+    yield f"CREATE TABLE {new_table.name} LIKE {existing_table.name};"
+    yield f"ALTER TABLE {new_table.name} REMOVE PARTITIONING;"
+    yield f"ALTER TABLE {new_table.name} PARTITION BY RANGE({range_id_string}) ("
+    yield f"\tPARTITION {max_val_part.name} VALUES LESS THAN MAXVALUE"
+    yield ");"
+
+    for command in alter_commands_iter:
+        yield command
+
+    cols = set(columns)
+
+    yield f"CREATE OR REPLACE TRIGGER copy_inserts_from_{existing_table.name}_to_{new_table.name}"
+    yield f"\tAFTER INSERT ON {existing_table.name} FOR EACH ROW"
+    yield f"\t\tINSERT INTO {new_table.name} SET"
+
+    for line in _suffix(
+        _trigger_column_copies(sorted(cols)),
+        indent="\t\t\t",
+        mid_suffix=",",
+        final_suffix=";",
+    ):
+        yield line
+
+    update_columns = cols.difference(set(map_data["range_cols"]))
+    if not update_columns:
+        log.info("No columns to copy, so no UPDATE trigger being constructed.")
+        return
+
+    yield f"CREATE OR REPLACE TRIGGER copy_updates_from_{existing_table.name}_to_{new_table.name}"
+    yield f"\tAFTER UPDATE ON {existing_table.name} FOR EACH ROW"
+    yield f"\t\tUPDATE {new_table.name} SET"
+
+    for line in _suffix(
+        _trigger_column_copies(sorted(update_columns)), indent="\t\t\t", mid_suffix=","
+    ):
+        yield line
+
+    yield "\t\tWHERE " + " AND ".join(
+        _trigger_column_copies(map_data["range_cols"])
+    ) + ";"
+
+    return
 
 
 def calculate_sql_alters_from_state_info(conf, in_fp):
@@ -130,14 +223,21 @@ def calculate_sql_alters_from_state_info(conf, in_fp):
             log.info(f"Skipping {table_name} as it is not in the current config")
             continue
 
-        problem = pm_tap.get_table_compatibility_problems(conf.dbcmd, table)
-        if problem:
-            raise Exception(problem)
+        map_data = None
 
-        map_data = pm_tap.get_partition_map(conf.dbcmd, table)
+        if not conf.assume_partitioned_on:
+            problem = pm_tap.get_table_compatibility_problems(conf.dbcmd, table)
+            if problem:
+                raise Exception(problem)
+            map_data = pm_tap.get_partition_map(conf.dbcmd, table)
+        else:
+            map_data = _override_config_to_map_data(conf)
+
         current_positions = pm_tap.get_current_positions(
             conf.dbcmd, table, map_data["range_cols"]
         )
+
+        columns = [r["Field"] for r in pm_tap.get_columns(conf.dbcmd, table)]
 
         ordered_current_pos = [
             current_positions[name] for name in map_data["range_cols"]
@@ -178,7 +278,17 @@ def calculate_sql_alters_from_state_info(conf, in_fp):
             max_val_part,
         )
 
+        table_new = partitionmanager.types.Table(
+            f"{table.name}_new_{conf.curtime:%Y%m%d}"
+        )
+
+        alter_commands_iter = pm_tap.generate_sql_reorganize_partition_commands(
+            table_new, changes
+        )
+
         commands[table.name] = list(
-            pm_tap.generate_sql_reorganize_partition_commands(table, changes)
+            _generate_sql_copy_commands(
+                table, map_data, columns, table_new, alter_commands_iter
+            )
         )
     return commands

--- a/partitionmanager/bootstrap_test.py
+++ b/partitionmanager/bootstrap_test.py
@@ -4,17 +4,30 @@ import yaml
 from datetime import datetime, timedelta
 
 from .bootstrap import (
+    _generate_sql_copy_commands,
     _get_time_offsets,
+    _suffix,
+    _trigger_column_copies,
+    _override_config_to_map_data,
+    _plan_partitions_for_time_offsets,
     calculate_sql_alters_from_state_info,
     write_state_info,
 )
 from .cli import Config
-from .types import DatabaseCommand, Table, SqlInput
+from .types import (
+    DatabaseCommand,
+    Table,
+    SqlInput,
+    MaxValuePartition,
+    ChangePlannedPartition,
+    NewPlannedPartition,
+)
 
 
 class MockDatabase(DatabaseCommand):
     def __init__(self):
-        self.response = []
+        self._response = list()
+        self._select_response = [[{"id": 150}]]
         self.num_queries = 0
 
     def run(self, cmd):
@@ -36,8 +49,9 @@ class MockDatabase(DatabaseCommand):
             ]
 
         if "SELECT" in cmd:
-            return [{"id": 150}]
-        return self.response
+            return self._select_response.pop()
+
+        return self._response.pop()
 
     def db_name(self):
         return SqlInput("the-database")
@@ -81,6 +95,7 @@ class TestBootstrapTool(unittest.TestCase):
         )
 
     def test_read_state_info(self):
+        self.maxDiff = None
         conf_past = Config()
         conf_past.curtime = datetime(2021, 3, 1)
         conf_past.dbcmd = MockDatabase()
@@ -96,6 +111,12 @@ class TestBootstrapTool(unittest.TestCase):
         conf_now = Config()
         conf_now.curtime = datetime(2021, 3, 3)
         conf_now.dbcmd = MockDatabase()
+        conf_now.dbcmd._response = [
+            [
+                {"Field": "id", "Type": "bigint UNSIGNED"},
+                {"Field": "serial", "Type": "varchar"},
+            ]
+        ]
         conf_now.tables = [Table("test").set_partition_period(timedelta(days=30))]
 
         state_fs.seek(0)
@@ -104,10 +125,148 @@ class TestBootstrapTool(unittest.TestCase):
             x,
             {
                 "test": [
-                    "ALTER TABLE `test` REORGANIZE PARTITION `p_start` INTO "
-                    "(PARTITION `p_20210303` VALUES LESS THAN (156), "
-                    "PARTITION `p_20210402` VALUES LESS THAN (2406), "
-                    "PARTITION `p_20210502` VALUES LESS THAN MAXVALUE);"
+                    "DROP TABLE IF EXISTS test_new_20210303;",
+                    "CREATE TABLE test_new_20210303 LIKE test;",
+                    "ALTER TABLE test_new_20210303 REMOVE PARTITIONING;",
+                    "ALTER TABLE test_new_20210303 PARTITION BY RANGE(id) (",
+                    "\tPARTITION p_start VALUES LESS THAN MAXVALUE",
+                    ");",
+                    "ALTER TABLE `test_new_20210303` REORGANIZE PARTITION `p_start` "
+                    + "INTO (PARTITION `p_20210303` VALUES LESS THAN (156), "
+                    + "PARTITION `p_20210402` VALUES LESS THAN (2406), PARTITION "
+                    + "`p_20210502` VALUES LESS THAN MAXVALUE);",
+                    "CREATE OR REPLACE TRIGGER copy_inserts_from_test_to_test_new_20210303",
+                    "\tAFTER INSERT ON test FOR EACH ROW",
+                    "\t\tINSERT INTO test_new_20210303 SET",
+                    "\t\t\t`id` = NEW.`id`,",
+                    "\t\t\t`serial` = NEW.`serial`;",
+                    "CREATE OR REPLACE TRIGGER copy_updates_from_test_to_test_new_20210303",
+                    "\tAFTER UPDATE ON test FOR EACH ROW",
+                    "\t\tUPDATE test_new_20210303 SET",
+                    "\t\t\t`serial` = NEW.`serial`",
+                    "\t\tWHERE `id` = NEW.`id`;",
                 ]
             },
         )
+
+    def test_read_state_info_map_table(self):
+        self.maxDiff = None
+        conf = Config()
+        conf.assume_partitioned_on = ["order", "auth"]
+        conf.curtime = datetime(2021, 3, 3)
+        conf.dbcmd = MockDatabase()
+        conf.dbcmd._select_response = [[{"auth": 22}], [{"order": 11}]]
+        conf.dbcmd._response = [
+            [
+                {"Field": "order", "Type": "bigint UNSIGNED"},
+                {"Field": "auth", "Type": "bigint UNSIGNED"},
+            ]
+        ]
+        conf.tables = [Table("map_table").set_partition_period(timedelta(days=30))]
+
+        state_fs = io.StringIO()
+        yaml.dump(
+            {
+                "tables": {"map_table": {"order": 11, "auth": 22}},
+                "time": (conf.curtime - timedelta(days=1)),
+            },
+            state_fs,
+        )
+        state_fs.seek(0)
+
+        x = calculate_sql_alters_from_state_info(conf, state_fs)
+        print(x)
+        self.assertEqual(
+            x,
+            {
+                "map_table": [
+                    "DROP TABLE IF EXISTS map_table_new_20210303;",
+                    "CREATE TABLE map_table_new_20210303 LIKE map_table;",
+                    "ALTER TABLE map_table_new_20210303 REMOVE PARTITIONING;",
+                    "ALTER TABLE map_table_new_20210303 PARTITION BY RANGE(order, auth) (",
+                    "\tPARTITION p_assumed VALUES LESS THAN MAXVALUE",
+                    ");",
+                    "ALTER TABLE `map_table_new_20210303` REORGANIZE PARTITION "
+                    + "`p_assumed` INTO (PARTITION `p_20210303` VALUES LESS THAN "
+                    + "(11, 22), PARTITION `p_20210402` VALUES LESS THAN "
+                    + "(11, 22), PARTITION `p_20210502` VALUES LESS THAN "
+                    + "MAXVALUE, MAXVALUE);",
+                    "CREATE OR REPLACE TRIGGER copy_inserts_from_map_table_"
+                    + "to_map_table_new_20210303",
+                    "\tAFTER INSERT ON map_table FOR EACH ROW",
+                    "\t\tINSERT INTO map_table_new_20210303 SET",
+                    "\t\t\t`auth` = NEW.`auth`,",
+                    "\t\t\t`order` = NEW.`order`;",
+                ]
+            },
+        )
+
+    def test_trigger_column_copies(self):
+        self.assertEqual(list(_trigger_column_copies([])), [])
+        self.assertEqual(list(_trigger_column_copies(["a"])), ["`a` = NEW.`a`"])
+        self.assertEqual(
+            list(_trigger_column_copies(["b", "a", "c"])),
+            ["`b` = NEW.`b`", "`a` = NEW.`a`", "`c` = NEW.`c`"],
+        )
+
+    def test_suffix(self):
+        self.assertEqual(list(_suffix(["a"])), ["a"])
+        self.assertEqual(list(_suffix(["a", "b"])), ["a", "b"])
+        self.assertEqual(list(_suffix(["a", "b"], indent=" ")), [" a", " b"])
+        self.assertEqual(list(_suffix(["a", "b"], mid_suffix=",")), ["a,", "b"])
+        self.assertEqual(list(_suffix(["a", "b"], final_suffix=";")), ["a", "b;"])
+        self.assertEqual(
+            list(_suffix(["a", "b"], mid_suffix=",", final_suffix=";")), ["a,", "b;"]
+        )
+
+    def test_generate_sql_copy_commands(self):
+        conf = Config()
+        conf.assume_partitioned_on = ["id"]
+        conf.curtime = datetime(2021, 3, 3)
+        conf.dbcmd = MockDatabase()
+        map_data = _override_config_to_map_data(conf)
+        cmds = list(
+            _generate_sql_copy_commands(
+                Table("old"),
+                map_data,
+                ["id", "field"],
+                Table("new"),
+                ["STRAIGHT_UP_INSERTED", "STUFF GOES HERE"],
+            )
+        )
+
+        print(cmds)
+        self.assertEqual(
+            cmds,
+            [
+                "DROP TABLE IF EXISTS new;",
+                "CREATE TABLE new LIKE old;",
+                "ALTER TABLE new REMOVE PARTITIONING;",
+                "ALTER TABLE new PARTITION BY RANGE(id) (",
+                "\tPARTITION p_assumed VALUES LESS THAN MAXVALUE",
+                ");",
+                "STRAIGHT_UP_INSERTED",
+                "STUFF GOES HERE",
+                "CREATE OR REPLACE TRIGGER copy_inserts_from_old_to_new",
+                "\tAFTER INSERT ON old FOR EACH ROW",
+                "\t\tINSERT INTO new SET",
+                "\t\t\t`field` = NEW.`field`,",
+                "\t\t\t`id` = NEW.`id`;",
+                "CREATE OR REPLACE TRIGGER copy_updates_from_old_to_new",
+                "\tAFTER UPDATE ON old FOR EACH ROW",
+                "\t\tUPDATE new SET",
+                "\t\t\t`field` = NEW.`field`",
+                "\t\tWHERE `id` = NEW.`id`;",
+            ],
+        )
+
+    def test_plan_partitions_for_time_offsets(self):
+        parts = _plan_partitions_for_time_offsets(
+            datetime(2021, 3, 3),
+            [timedelta(days=60), timedelta(days=360)],
+            [11943234],
+            [16753227640],
+            MaxValuePartition("p_assumed", count=1),
+        )
+        self.assertIsInstance(parts[0], ChangePlannedPartition)
+        self.assertIsInstance(parts[1], NewPlannedPartition)

--- a/partitionmanager/cli.py
+++ b/partitionmanager/cli.py
@@ -59,6 +59,7 @@ class Config:
         self.curtime = datetime.now(tz=timezone.utc)
         self.partition_period = timedelta(days=30)
         self.prometheus_stats_path = None
+        self.assume_partitioned_on = None
 
     def from_argparse(self, args):
         """Populate this config from an argparse result.
@@ -80,6 +81,8 @@ class Config:
             self.noop = args.noop
         if "prometheus_stats" in args:
             self.prometheus_stats_path = args.prometheus_stats
+        if "assume_partitioned_on" in args:
+            self.assume_partitioned_on = args.assume_partitioned_on
 
     def from_yaml_file(self, file):
         """Populate this config from the yaml in the file-like object supplied.
@@ -250,6 +253,13 @@ BOOTSTRAP_PARSER.add_argument(
     type=partitionmanager.types.SqlInput,
     nargs="+",
     help="table names, overwriting config",
+)
+BOOTSTRAP_PARSER.add_argument(
+    "--assume-partitioned-on",
+    type=partitionmanager.types.SqlInput,
+    action="append",
+    help="Assume tables are partitioned by this column name, can be specified "
+    "multiple times for multi-column partitions",
 )
 BOOTSTRAP_PARSER.set_defaults(func=bootstrap_cmd)
 
@@ -424,7 +434,7 @@ def main():
                     print(f" {k}: {v}")
             elif isinstance(output[key], list):
                 for v in output[key]:
-                    print(f" - {v}")
+                    print(f"# {v}")
             else:
                 print(f" {output[key]}")
     except Exception as e:

--- a/partitionmanager/cli_test.py
+++ b/partitionmanager/cli_test.py
@@ -490,7 +490,7 @@ partitionmanager:
                         "ALTER TABLE partitioned_yesterday_new_20210421 "
                         + "REMOVE PARTITIONING;",
                         "ALTER TABLE partitioned_yesterday_new_20210421 "
-                        + "PARTITION BY RANGE(id) (",
+                        + "PARTITION BY RANGE (id) (",
                         "\tPARTITION p_assumed VALUES LESS THAN MAXVALUE",
                         ");",
                         "ALTER TABLE `partitioned_yesterday_new_20210421` "
@@ -515,7 +515,7 @@ partitionmanager:
                         "DROP TABLE IF EXISTS two_new_20210421;",
                         "CREATE TABLE two_new_20210421 LIKE two;",
                         "ALTER TABLE two_new_20210421 REMOVE PARTITIONING;",
-                        "ALTER TABLE two_new_20210421 PARTITION BY RANGE(id) (",
+                        "ALTER TABLE two_new_20210421 PARTITION BY RANGE (id) (",
                         "\tPARTITION p_assumed VALUES LESS THAN MAXVALUE",
                         ");",
                         "ALTER TABLE `two_new_20210421` REORGANIZE PARTITION "
@@ -575,7 +575,7 @@ partitionmanager:
                         "DROP TABLE IF EXISTS unpartitioned_new_20210421;",
                         "CREATE TABLE unpartitioned_new_20210421 LIKE unpartitioned;",
                         "ALTER TABLE unpartitioned_new_20210421 REMOVE PARTITIONING;",
-                        "ALTER TABLE unpartitioned_new_20210421 PARTITION BY RANGE(id) (",
+                        "ALTER TABLE unpartitioned_new_20210421 PARTITION BY RANGE (id) (",
                         "\tPARTITION p_assumed VALUES LESS THAN MAXVALUE",
                         ");",
                         "ALTER TABLE `unpartitioned_new_20210421` REORGANIZE "

--- a/partitionmanager/cli_test.py
+++ b/partitionmanager/cli_test.py
@@ -1,16 +1,20 @@
 import tempfile
 import unittest
 import pymysql
+import yaml
 from datetime import datetime, timezone
 from pathlib import Path
 from .cli import (
     all_configured_tables_are_compatible,
+    bootstrap_cmd,
     config_from_args,
     do_partition,
     PARSER,
     partition_cmd,
     stats_cmd,
 )
+from .bootstrap import calculate_sql_alters_from_state_info
+
 
 fake_exec = Path(__file__).absolute().parent.parent / "test_tools/fake_mariadb.sh"
 nonexistant_exec = fake_exec.parent / "not_real"
@@ -371,3 +375,245 @@ partitionmanager:
 """,
                 datetime.now(),
             )
+
+    def test_bootstrap_cmd_out(self):
+        with tempfile.NamedTemporaryFile() as outfile:
+            args = PARSER.parse_args(
+                [
+                    "--mariadb",
+                    str(fake_exec),
+                    "bootstrap",
+                    "--out",
+                    outfile.name,
+                    "--table",
+                    "partitioned_yesterday",
+                    "two",
+                ]
+            )
+
+            output = bootstrap_cmd(args)
+            self.assertEqual({}, output)
+
+            out_yaml = yaml.safe_load(Path(outfile.name).read_text())
+            self.assertTrue("time" in out_yaml)
+            self.assertTrue(isinstance(out_yaml["time"], datetime))
+            del out_yaml["time"]
+
+            self.assertEqual(
+                out_yaml,
+                {"tables": {"partitioned_yesterday": {"id": 150}, "two": {"id": 150}}},
+            )
+
+    def test_bootstrap_cmd_out_unpartitioned(self):
+        with tempfile.NamedTemporaryFile() as outfile:
+            args = PARSER.parse_args(
+                [
+                    "--mariadb",
+                    str(fake_exec),
+                    "bootstrap",
+                    "--out",
+                    outfile.name,
+                    "--table",
+                    "unpartitioned",
+                    "two",
+                ]
+            )
+
+            with self.assertRaisesRegex(
+                Exception, "Table unpartitioned is not partitioned"
+            ):
+                bootstrap_cmd(args)
+
+    def test_bootstrap_cmd_out_unpartitioned_with_override(self):
+        with tempfile.NamedTemporaryFile() as outfile:
+            args = PARSER.parse_args(
+                [
+                    "--mariadb",
+                    str(fake_exec),
+                    "bootstrap",
+                    "--assume-partitioned-on",
+                    "id",
+                    "--out",
+                    outfile.name,
+                    "--table",
+                    "unpartitioned",
+                ]
+            )
+            output = bootstrap_cmd(args)
+            self.assertEqual({}, output)
+
+            out_yaml = yaml.safe_load(Path(outfile.name).read_text())
+            self.assertTrue("time" in out_yaml)
+            self.assertTrue(isinstance(out_yaml["time"], datetime))
+            del out_yaml["time"]
+
+            self.assertEqual(out_yaml, {"tables": {"unpartitioned": {"id": 150}}})
+
+    def test_bootstrap_cmd_in(self):
+        with tempfile.NamedTemporaryFile(mode="w+") as infile:
+            yaml.dump(
+                {
+                    "tables": {"partitioned_yesterday": {"id": 50}, "two": {"id": 0}},
+                    "time": datetime(2021, 4, 1, tzinfo=timezone.utc),
+                },
+                infile,
+            )
+
+            args = PARSER.parse_args(
+                [
+                    "--mariadb",
+                    str(fake_exec),
+                    "bootstrap",
+                    "--in",
+                    infile.name,
+                    "--table",
+                    "partitioned_yesterday",
+                    "two",
+                ]
+            )
+
+            conf = config_from_args(args)
+            conf.assume_partitioned_on = ["id"]
+            conf.curtime = datetime(2021, 4, 21, tzinfo=timezone.utc)
+            self.maxDiff = None
+
+            output = calculate_sql_alters_from_state_info(
+                conf, Path(infile.name).open("r")
+            )
+            self.assertEqual(
+                output,
+                {
+                    "partitioned_yesterday": [
+                        "DROP TABLE IF EXISTS partitioned_yesterday_new_20210421;",
+                        "CREATE TABLE partitioned_yesterday_new_20210421 "
+                        + "LIKE partitioned_yesterday;",
+                        "ALTER TABLE partitioned_yesterday_new_20210421 "
+                        + "REMOVE PARTITIONING;",
+                        "ALTER TABLE partitioned_yesterday_new_20210421 "
+                        + "PARTITION BY RANGE(id) (",
+                        "\tPARTITION p_assumed VALUES LESS THAN MAXVALUE",
+                        ");",
+                        "ALTER TABLE `partitioned_yesterday_new_20210421` "
+                        + "REORGANIZE PARTITION `p_assumed` INTO (PARTITION "
+                        + "`p_20210421` VALUES LESS THAN (150), PARTITION "
+                        + "`p_20210521` VALUES LESS THAN (300), PARTITION "
+                        + "`p_20210620` VALUES LESS THAN MAXVALUE);",
+                        "CREATE OR REPLACE TRIGGER copy_inserts_from_"
+                        + "partitioned_yesterday_to_partitioned_yesterday_new_20210421",
+                        "\tAFTER INSERT ON partitioned_yesterday FOR EACH ROW",
+                        "\t\tINSERT INTO partitioned_yesterday_new_20210421 SET",
+                        "\t\t\t`id` = NEW.`id`,",
+                        "\t\t\t`serial` = NEW.`serial`;",
+                        "CREATE OR REPLACE TRIGGER copy_updates_from_"
+                        + "partitioned_yesterday_to_partitioned_yesterday_new_20210421",
+                        "\tAFTER UPDATE ON partitioned_yesterday FOR EACH ROW",
+                        "\t\tUPDATE partitioned_yesterday_new_20210421 SET",
+                        "\t\t\t`serial` = NEW.`serial`",
+                        "\t\tWHERE `id` = NEW.`id`;",
+                    ],
+                    "two": [
+                        "DROP TABLE IF EXISTS two_new_20210421;",
+                        "CREATE TABLE two_new_20210421 LIKE two;",
+                        "ALTER TABLE two_new_20210421 REMOVE PARTITIONING;",
+                        "ALTER TABLE two_new_20210421 PARTITION BY RANGE(id) (",
+                        "\tPARTITION p_assumed VALUES LESS THAN MAXVALUE",
+                        ");",
+                        "ALTER TABLE `two_new_20210421` REORGANIZE PARTITION "
+                        + "`p_assumed` INTO (PARTITION `p_20210421` VALUES "
+                        + "LESS THAN (150), PARTITION `p_20210521` VALUES LESS "
+                        + "THAN (375), PARTITION `p_20210620` VALUES LESS THAN "
+                        + "MAXVALUE);",
+                        "CREATE OR REPLACE TRIGGER copy_inserts_from_two_to_two_new_20210421",
+                        "\tAFTER INSERT ON two FOR EACH ROW",
+                        "\t\tINSERT INTO two_new_20210421 SET",
+                        "\t\t\t`id` = NEW.`id`,",
+                        "\t\t\t`serial` = NEW.`serial`;",
+                        "CREATE OR REPLACE TRIGGER copy_updates_from_two_to_two_new_20210421",
+                        "\tAFTER UPDATE ON two FOR EACH ROW",
+                        "\t\tUPDATE two_new_20210421 SET",
+                        "\t\t\t`serial` = NEW.`serial`",
+                        "\t\tWHERE `id` = NEW.`id`;",
+                    ],
+                },
+            )
+
+    def test_bootstrap_cmd_in_unpartitioned_with_override(self):
+        with tempfile.NamedTemporaryFile(mode="w+") as infile:
+            yaml.dump(
+                {
+                    "tables": {"unpartitioned": {"id": 50}},
+                    "time": datetime(2021, 4, 1, tzinfo=timezone.utc),
+                },
+                infile,
+            )
+
+            args = PARSER.parse_args(
+                [
+                    "--mariadb",
+                    str(fake_exec),
+                    "bootstrap",
+                    "--assume-partitioned-on",
+                    "id",
+                    "--in",
+                    infile.name,
+                    "--table",
+                    "unpartitioned",
+                ]
+            )
+            conf = config_from_args(args)
+            conf.curtime = datetime(2021, 4, 21, tzinfo=timezone.utc)
+            self.maxDiff = None
+
+            output = calculate_sql_alters_from_state_info(
+                conf, Path(infile.name).open("r")
+            )
+
+            self.assertEqual(
+                output,
+                {
+                    "unpartitioned": [
+                        "DROP TABLE IF EXISTS unpartitioned_new_20210421;",
+                        "CREATE TABLE unpartitioned_new_20210421 LIKE unpartitioned;",
+                        "ALTER TABLE unpartitioned_new_20210421 REMOVE PARTITIONING;",
+                        "ALTER TABLE unpartitioned_new_20210421 PARTITION BY RANGE(id) (",
+                        "\tPARTITION p_assumed VALUES LESS THAN MAXVALUE",
+                        ");",
+                        "ALTER TABLE `unpartitioned_new_20210421` REORGANIZE "
+                        + "PARTITION `p_assumed` INTO (PARTITION `p_20210421` "
+                        + "VALUES LESS THAN (150), PARTITION `p_20210521` VALUES "
+                        + "LESS THAN (300), PARTITION `p_20210620` VALUES LESS "
+                        + "THAN MAXVALUE);",
+                        "CREATE OR REPLACE TRIGGER copy_inserts_from_"
+                        + "unpartitioned_to_unpartitioned_new_20210421",
+                        "\tAFTER INSERT ON unpartitioned FOR EACH ROW",
+                        "\t\tINSERT INTO unpartitioned_new_20210421 SET",
+                        "\t\t\t`id` = NEW.`id`,",
+                        "\t\t\t`serial` = NEW.`serial`;",
+                        "CREATE OR REPLACE TRIGGER copy_updates_from_"
+                        + "unpartitioned_to_unpartitioned_new_20210421",
+                        "\tAFTER UPDATE ON unpartitioned FOR EACH ROW",
+                        "\t\tUPDATE unpartitioned_new_20210421 SET",
+                        "\t\t\t`serial` = NEW.`serial`",
+                        "\t\tWHERE `id` = NEW.`id`;",
+                    ]
+                },
+            )
+
+    def test_bootstrap_cmd_in_out(self):
+        with tempfile.NamedTemporaryFile() as outfile, tempfile.NamedTemporaryFile(
+            mode="w+"
+        ) as infile:
+            with self.assertRaises(SystemExit):
+                PARSER.parse_args(
+                    [
+                        "--mariadb",
+                        str(fake_exec),
+                        "bootstrap",
+                        "--out",
+                        outfile.name,
+                        "--in",
+                        infile.name,
+                        "--table",
+                        "flip",
+                    ]
+                )

--- a/partitionmanager/sql.py
+++ b/partitionmanager/sql.py
@@ -125,6 +125,7 @@ class SubprocessDatabaseCommand(partitionmanager.types.DatabaseCommand):
         self.exe = exe
 
     def run(self, sql_cmd):
+        logging.debug(f"SubprocessDatabaseCommand executing {sql_cmd}")
         result = subprocess.run(
             [self.exe, "-X"],
             input=sql_cmd,
@@ -170,6 +171,7 @@ class IntegratedDatabaseCommand(partitionmanager.types.DatabaseCommand):
         return partitionmanager.types.SqlInput(self.db)
 
     def run(self, sql_cmd):
+        logging.debug(f"IntegratedDatabaseCommand executing {sql_cmd}")
         with self.connection.cursor() as cursor:
             cursor.execute(sql_cmd)
             return [row for row in cursor]

--- a/partitionmanager/table_append_partition_test.py
+++ b/partitionmanager/table_append_partition_test.py
@@ -22,6 +22,7 @@ from partitionmanager.table_append_partition import (
     _get_position_increase_per_day,
     _get_table_information_schema_problems,
     _get_weighted_position_increase_per_day_for_partitions,
+    _parse_columns,
     _parse_partition_map,
     _plan_partition_changes,
     _predict_forward_position,
@@ -33,6 +34,7 @@ from partitionmanager.table_append_partition import (
     get_partition_map,
     get_pending_sql_reorganize_partition_commands,
     get_table_compatibility_problems,
+    get_columns,
 )
 
 from .types_test import mkPPart, mkTailPart, mkPos
@@ -1051,6 +1053,35 @@ class TestPartitionAlgorithm(unittest.TestCase):
                 "PARTITION `p_20210123` VALUES LESS THAN MAXVALUE);"
             ],
         )
+
+    def test_get_columns(self):
+        db = MockDatabase()
+        db.response = [{"Field": "id", "Type": "int"}, {"Field": "day", "Type": "int"}]
+
+        columns = get_columns(db, Table("table"))
+
+        self.assertEqual(columns, db.response)
+
+    def test_parse_columns(self):
+        column_descriptions = [
+            {"Field": "id", "Type": "int", "Extra": 3},
+            {"Field": "day", "Type": "int"},
+        ]
+        self.assertEqual(
+            _parse_columns(Table("table"), column_descriptions), column_descriptions
+        )
+
+        with self.assertRaises(TableInformationException):
+            _parse_columns(Table("table"), [])
+
+        with self.assertRaises(TableInformationException):
+            _parse_columns(Table("table"), [{"Type": "melee_range"}])
+
+        with self.assertRaises(TableInformationException):
+            _parse_columns(Table("table"), [{"Field": "five_feet"}])
+
+        with self.assertRaises(TableInformationException):
+            _parse_columns(Table("table"), [{"Field": "five_feet"}])
 
 
 if __name__ == "__main__":

--- a/partitionmanager/types.py
+++ b/partitionmanager/types.py
@@ -313,7 +313,9 @@ class MaxValuePartition(_Partition):
         return self._count
 
     def values(self):
-        return ", ".join(["MAXVALUE"] * self._count)
+        if self._count == 1:
+            return "MAXVALUE"
+        return "(" + ", ".join(["MAXVALUE"] * self._count) + ")"
 
     def __lt__(self, other):
         """MaxValuePartitions are always greater than every other partition."""

--- a/test_tools/fake_mariadb.sh
+++ b/test_tools/fake_mariadb.sh
@@ -64,7 +64,7 @@ if echo $stdin | grep "SHOW CREATE" >/dev/null; then
     tailPartName="p_20201204"
   fi
 
-	cat <<EOF
+  cat <<EOF
 <?xml version="1.0"?>
 
 <resultset statement="show create table burgers" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -74,6 +74,15 @@ if echo $stdin | grep "SHOW CREATE" >/dev/null; then
   \`id\` bigint(20) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (\`id\`),
 ) ENGINE=InnoDB AUTO_INCREMENT=150 DEFAULT CHARSET=utf8
+EOF
+  if echo $stdin | grep "unpartitioned" >/dev/null; then
+    cat <<EOF
+    </field>
+  </row>
+</resultset>
+EOF
+  else
+    cat <<EOF
  PARTITION BY RANGE (\`id\`)
 (PARTITION \`${earlyPartName}\` VALUES LESS THAN (100) ENGINE = InnoDB,
  PARTITION \`${midPartName}\` VALUES LESS THAN (200) ENGINE = InnoDB,
@@ -81,6 +90,7 @@ if echo $stdin | grep "SHOW CREATE" >/dev/null; then
   </row>
 </resultset>
 EOF
+  fi
 	exit
 fi
 
@@ -101,6 +111,24 @@ if echo $stdin | grep "SELECT DATABASE" >/dev/null; then
 <resultset statement="select database()" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <row>
     <field name="DATABASE()">tasty-treats</field>
+  </row>
+</resultset>
+EOF
+    exit
+fi
+
+if echo $stdin | grep "DESCRIBE" >/dev/null; then
+    cat <<EOF
+<?xml version="1.0"?>
+
+<resultset statement="DESCRIBE yada yada" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <row>
+    <field name="Field">id</field>
+    <field name="Type">bigint(20)</field>
+  </row>
+  <row>
+    <field name="Field">serial</field>
+    <field name="Type">varchar(20)</field>
   </row>
 </resultset>
 EOF


### PR DESCRIPTION
Add an `--assume-partitioned-on` flag to bootstrap, to facilitate operation on
tables that do not yet have a partition map. One needs to supply
`--assume-partitioned-on COLUMN_NAME` as many times as needed to identify all
the columns which will be part of the partition expression.

The 'bootstrap' command now emits table-copy instructions

The original plan for 'bootstrap' was to do live alterations, that they should
only lock what they needed, however InnoDB likes to lock everything. So instead
we need to always assume that "bootstrapping" will be a live table clone,
and at their conclusion the team should perform an atomic rename.