### PR TITLE
Ignore rate calculations for out-of-order partitions

### DIFF
--- a/partitionmanager/table_append_partition_test.py
+++ b/partitionmanager/table_append_partition_test.py
@@ -356,13 +356,15 @@ class TestPartitionAlgorithm(unittest.TestCase):
             )
         with self.assertRaises(ValueError):
             _get_position_increase_per_day(
-                mkPPart("p_20211231", 99), mkPPart("p_20210101", 42)
-            )
-        with self.assertRaises(ValueError):
-            _get_position_increase_per_day(
                 mkPPart("p_20201231", 1, 99), mkPPart("p_20210101", 42)
             )
 
+        self.assertEqual(
+            _get_position_increase_per_day(
+                mkPPart("p_20211231", 99), mkPPart("p_20210101", 42)
+            ),
+            [],
+        )
         self.assertEqual(
             _get_position_increase_per_day(
                 mkPPart("p_20201231", 0), mkPPart("p_20210101", 100)


### PR DESCRIPTION
If on a previous run (or absence of run) we let some periods get de-synced so
that the timestamps don't increase smoothly, then don't get stuck on that
unfortunateness and instead ignore them for rate calculations.