### PR TITLE
Use actual data for date predictions if available, not partition names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ partitionmanager:
     table4: {}
 ```
 
+The `insertion_date_query` entries are optional SQL queries that are run during partition map analysis to determine the eact timestamp of the earliest entry in each partition. If you configure such a query for a table, it must return a single row and column, specifically the epoch timestamp in UTC of the earliest entry the partition. There is expcected a single `?` entry which will be replaced with the partition value of that partition.
+
 For tables which are either partitioned but not yet using this tool's schema, or which have no empty partitions, the `migrate` command can be useful for proposing alterations to run manually. Note that `migrate` proposes commands that are likely to require partial copies of each table, so likely they will require a maintenance period.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Similar tools:
   dburl: "sql://user:password@localhost3306:/test_db"
   tables:
     cats:
-      insertion_date_query: >
+      earliest_utc_timestamp_query: >
         SELECT UNIX_TIMESTAMP(created) FROM cats WHERE id > ? ORDER BY id ASC LIMIT 1;
     dogs:
       partition_period:
         days: 30
-      insertion_date_query: >
+      earliest_utc_timestamp_query: >
         SELECT UNIX_TIMESTAMP(c.created) FROM dogs AS d JOIN cats AS c ON c.house_id = d.house_id WHERE d.id > ? ORDER BY d.id ASC LIMIT 1;
   prometheus_stats: "/tmp/prometheus-textcollect-partition-manager.prom"
 EOF
@@ -84,22 +84,22 @@ partitionmanager:
     table1:
       retention:
         days: 60
-      insertion_date_query: >
+      earliest_utc_timestamp_query: >
         SELECT UNIX_TIMESTAMP(created) FROM table1 WHERE id > ? ORDER BY id ASC LIMIT 1;
     table2:
       partition_period:
         days: 30
-      insertion_date_query: >
+      earliest_utc_timestamp_query: >
         SELECT UNIX_TIMESTAMP(created) FROM table2 WHERE id > ? ORDER BY id ASC LIMIT 1;
     table3:
       retention:
         days: 14
-      insertion_date_query: >
+      earliest_utc_timestamp_query: >
         SELECT UNIX_TIMESTAMP(created) FROM table3 WHERE id > ? ORDER BY id ASC LIMIT 1;
     table4: {}
 ```
 
-The `insertion_date_query` entries are optional SQL queries that are run during partition map analysis to determine the eact timestamp of the earliest entry in each partition. If you configure such a query for a table, it must return a single row and column, specifically the epoch timestamp in UTC of the earliest entry the partition. There is expcected a single `?` entry which will be replaced with the partition value of that partition.
+The `earliest_utc_timestamp_query` entries are optional SQL queries that are run during partition map analysis to determine the eact timestamp of the earliest entry in each partition. If you configure such a query for a table, it must return a single row and column, specifically the epoch timestamp in UTC of the earliest entry the partition. There is expcected a single `?` entry which will be replaced with the partition value of that partition.
 
 For tables which are either partitioned but not yet using this tool's schema, or which have no empty partitions, the `migrate` command can be useful for proposing alterations to run manually. Note that `migrate` proposes commands that are likely to require partial copies of each table, so likely they will require a maintenance period.
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,14 @@ Similar tools:
       days: 90
   dburl: "sql://user:password@localhost3306:/test_db"
   tables:
-    cats: {}
+    cats:
+      insertion_date_query: >
+        SELECT UNIX_TIMESTAMP(created) FROM cats WHERE id > ? ORDER BY id ASC LIMIT 1;
     dogs:
       partition_period:
         days: 30
+      insertion_date_query: >
+        SELECT UNIX_TIMESTAMP(c.created) FROM dogs AS d JOIN cats AS c ON c.house_id = d.house_id WHERE d.id > ? ORDER BY d.id ASC LIMIT 1;
   prometheus_stats: "/tmp/prometheus-textcollect-partition-manager.prom"
 EOF
  → partition-manager --config /tmp/partman.conf.yml maintain --noop
@@ -80,12 +84,18 @@ partitionmanager:
     table1:
       retention:
         days: 60
+      insertion_date_query: >
+        SELECT UNIX_TIMESTAMP(created) FROM table1 WHERE id > ? ORDER BY id ASC LIMIT 1;
     table2:
       partition_period:
         days: 30
+      insertion_date_query: >
+        SELECT UNIX_TIMESTAMP(created) FROM table2 WHERE id > ? ORDER BY id ASC LIMIT 1;
     table3:
       retention:
         days: 14
+      insertion_date_query: >
+        SELECT UNIX_TIMESTAMP(created) FROM table3 WHERE id > ? ORDER BY id ASC LIMIT 1;
     table4: {}
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,12 +30,15 @@ Similar tools:
   tables:
     cats:
       earliest_utc_timestamp_query: >
-        SELECT UNIX_TIMESTAMP(created) FROM cats WHERE id > ? ORDER BY id ASC LIMIT 1;
+        SELECT UNIX_TIMESTAMP(`created`) FROM `cats` WHERE `id` > '?' ORDER BY `id` ASC LIMIT 1;
     dogs:
       partition_period:
         days: 30
       earliest_utc_timestamp_query: >
-        SELECT UNIX_TIMESTAMP(c.created) FROM dogs AS d JOIN cats AS c ON c.house_id = d.house_id WHERE d.id > ? ORDER BY d.id ASC LIMIT 1;
+        SELECT UNIX_TIMESTAMP(`c`.`created`) FROM `dogs` AS `d`
+          JOIN `cats` AS `c` ON `c`.`house_id` = `d`.`house_id`
+          WHERE `d`.`id` > '?'
+          ORDER BY `d`.`id` ASC LIMIT 1;
   prometheus_stats: "/tmp/prometheus-textcollect-partition-manager.prom"
 EOF
  → partition-manager --config /tmp/partman.conf.yml maintain --noop

--- a/partitionmanager/cli.py
+++ b/partitionmanager/cli.py
@@ -133,6 +133,12 @@ class Config:
                             tabledata["partition_period"]
                         )
                     )
+                if isinstance(tabledata, dict) and "insertion_date_query" in tabledata:
+                    tab.set_insertion_date_query(
+                        partitionmanager.types.SqlQuery(
+                            tabledata["insertion_date_query"]
+                        )
+                    )
 
                 self.tables.add(tab)
         if "prometheus_stats" in data:
@@ -327,6 +333,7 @@ def do_partition(conf):
             cur_pos.set_position([positions[col] for col in map_data["range_cols"]])
 
             sql_cmds = pm_tap.get_pending_sql_reorganize_partition_commands(
+                database=conf.dbcmd,
                 table=table,
                 partition_list=map_data["partitions"],
                 current_position=cur_pos,

--- a/partitionmanager/cli.py
+++ b/partitionmanager/cli.py
@@ -133,10 +133,13 @@ class Config:
                             tabledata["partition_period"]
                         )
                     )
-                if isinstance(tabledata, dict) and "insertion_date_query" in tabledata:
-                    tab.set_insertion_date_query(
+                if (
+                    isinstance(tabledata, dict)
+                    and "earliest_utc_timestamp_query" in tabledata
+                ):
+                    tab.set_earliest_utc_timestamp_query(
                         partitionmanager.types.SqlQuery(
-                            tabledata["insertion_date_query"]
+                            tabledata["earliest_utc_timestamp_query"]
                         )
                     )
 

--- a/partitionmanager/table_append_partition.py
+++ b/partitionmanager/table_append_partition.py
@@ -433,7 +433,9 @@ def _get_rate_partitions_with_queried_timestamps(
             )
         arg = partition.position.as_sql_input()[0]
 
-        sql_select_cmd = table.insertion_date_query.get_statement_with_argument(arg)
+        sql_select_cmd = table.earliest_utc_timestamp_query.get_statement_with_argument(
+            arg
+        )
         log.debug(
             "Executing %s to derive partition %s at position %s",
             sql_select_cmd,

--- a/partitionmanager/table_append_partition.py
+++ b/partitionmanager/table_append_partition.py
@@ -2,7 +2,7 @@
 Design and perform partition management.
 """
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 import logging
 import operator
 import re
@@ -360,7 +360,122 @@ def _calculate_start_time(last_changed_time, evaluation_time, allowed_lifespan):
     return partition_start_time.replace(minute=0, second=0, microsecond=0)
 
 
+def _get_rate_partitions_with_implicit_timestamps(
+    table, filled_partitions, current_position, evaluation_time, active_partition
+):
+    """ Return a list of PositionPartitions for use in rate calculations.
+
+    The partitions are set with implicit timestamps.
+    """
+    log = logging.getLogger(
+        f"_get_rate_partitions_with_implicit_timestamps:{table.name}"
+    )
+
+    rate_relevant_partitions = None
+
+    if active_partition.timestamp() < evaluation_time:
+        # This bit of weirdness is a fencepost issue: The partition list is strictly
+        # increasing until we get to "now" and the active partition. "Now" actually
+        # takes place _after_ active partition's start date (naturally), but
+        # contains a position that is before the top of active, by definition. For
+        # the rate processing to work, we need to swap the "now" and the active
+        # partition's dates and positions.
+        rate_relevant_partitions = filled_partitions + [
+            partitionmanager.types.InstantPartition(
+                "p_current_pos", active_partition.timestamp(), current_position
+            ),
+            partitionmanager.types.InstantPartition(
+                "p_prev_pos", evaluation_time, active_partition.position
+            ),
+        ]
+    else:
+        # If the active partition's start date is later than today, then we
+        # previously mispredicted the rate of change. There's nothing we can
+        # do about that at this point, except limit our rate-of-change calculation
+        # to exclude the future-dated, irrelevant partition.
+        log.debug(
+            f"Misprediction: Evaluation time ({evaluation_time}) is "
+            f"before the active partition {active_partition}. Excluding "
+            "mispredicted partitions from the rate calculations."
+        )
+        filled_partitions = filter(
+            lambda f: f.timestamp() < evaluation_time, filled_partitions
+        )
+        rate_relevant_partitions = list(filled_partitions) + [
+            partitionmanager.types.InstantPartition(
+                "p_current_pos", evaluation_time, current_position
+            )
+        ]
+
+    return rate_relevant_partitions
+
+
+def _get_rate_partitions_with_queried_timestamps(
+    database, table, partition_list, current_position, evaluation_time, active_partition
+):
+    """ Return a list of PositionPartitions for use in rate calculations.
+
+    The partitions' timestamps are explicitly queried.
+    """
+    log = logging.getLogger(
+        f"_get_rate_partitions_with_queried_timestamps:{table.name}"
+    )
+
+    if not table.has_date_query:
+        raise ValueError("Table has no defined date query")
+
+    instant_partitions = list()
+
+    for partition in partition_list:
+        if len(partition.position) != 1:
+            raise ValueError(
+                "This method is only valid for single-column partitions right now"
+            )
+        arg = partition.position.as_sql_input()[0]
+
+        sql_select_cmd = table.insertion_date_query.get_statement_with_argument(arg)
+        log.debug(
+            "Executing %s to derive partition %s at position %s",
+            sql_select_cmd,
+            partition.name,
+            partition.position,
+        )
+
+        start = datetime.now()
+        exact_time_result = database.run(sql_select_cmd)
+        end = datetime.now()
+
+        assert len(exact_time_result) == 1
+        assert len(exact_time_result[0]) == 1
+        for key, value in exact_time_result[0].items():
+            exact_time = datetime.fromtimestamp(value, tz=timezone.utc)
+            break
+
+        log.debug(
+            "Exact time of %s returned for %s at position %s, query took %s",
+            exact_time,
+            partition.name,
+            partition.position,
+            (end - start),
+        )
+
+        instant_partitions.append(
+            partitionmanager.types.InstantPartition(
+                partition.name, exact_time, partition.position
+            )
+        )
+
+    instant_partitions.append(
+        partitionmanager.types.InstantPartition(
+            active_partition.name, evaluation_time, current_position
+        )
+    )
+
+    return instant_partitions
+
+
 def _plan_partition_changes(
+    database,
     table,
     partition_list,
     current_position,
@@ -389,43 +504,28 @@ def _plan_partition_changes(
     if not active_partition:
         raise Exception("Active Partition can't be None")
 
-    rate_relevant_partitions = None
-
-    if active_partition.timestamp() < evaluation_time:
-        # This bit of weirdness is a fencepost issue: The partition list is strictly
-        # increasing until we get to "now" and the active partition. "Now" actually
-        # takes place _after_ active partition's start date (naturally), but
-        # contains a position that is before the top of active, by definition. For
-        # the rate processing to work, we need to swap the "now" and the active
-        # partition's dates and positions.
-        rate_relevant_partitions = filled_partitions + [
-            partitionmanager.types.InstantPartition(
-                active_partition.timestamp(), current_position
-            ),
-            partitionmanager.types.InstantPartition(
-                evaluation_time, active_partition.position
-            ),
-        ]
+    if table.has_date_query:
+        rate_relevant_partitions = _get_rate_partitions_with_queried_timestamps(
+            database,
+            table,
+            filled_partitions,
+            current_position,
+            evaluation_time,
+            active_partition,
+        )
     else:
-        # If the active partition's start date is later than today, then we
-        # previously mispredicted the rate of change. There's nothing we can
-        # do about that at this point, except limit our rate-of-change calculation
-        # to exclude the future-dated, irrelevant partition.
-        log.debug(
-            f"Misprediction: Evaluation time ({evaluation_time}) is "
-            f"before the active partition {active_partition}. Excluding "
-            "mispredicted partitions from the rate calculations."
+        rate_relevant_partitions = _get_rate_partitions_with_implicit_timestamps(
+            table,
+            filled_partitions,
+            current_position,
+            evaluation_time,
+            active_partition,
         )
-        filled_partitions = filter(
-            lambda f: f.timestamp() < evaluation_time, filled_partitions
-        )
-        rate_relevant_partitions = list(filled_partitions) + [
-            partitionmanager.types.InstantPartition(evaluation_time, current_position)
-        ]
 
     rates = _get_weighted_position_increase_per_day_for_partitions(
         rate_relevant_partitions
     )
+
     log.debug(
         f"Rates of change calculated as {rates} per day from "
         f"{len(rate_relevant_partitions)} partitions"
@@ -620,6 +720,7 @@ def generate_sql_reorganize_partition_commands(table, changes):
 
 def get_pending_sql_reorganize_partition_commands(
     *,
+    database,
     table,
     partition_list,
     current_position,
@@ -656,6 +757,7 @@ def get_pending_sql_reorganize_partition_commands(
     )
 
     partition_changes = _plan_partition_changes(
+        database,
         table,
         partition_list,
         current_position,

--- a/partitionmanager/table_append_partition_test.py
+++ b/partitionmanager/table_append_partition_test.py
@@ -835,7 +835,7 @@ class TestPartitionAlgorithm(unittest.TestCase):
             datetime(2021, 5, 8, tzinfo=timezone.utc),
         ]
         tbl = Table("table")
-        tbl.set_insertion_date_query(
+        tbl.set_earliest_utc_timestamp_query(
             SqlQuery("SELECT insert_date FROM table WHERE id = ?;")
         )
         database = MockDatabase()

--- a/partitionmanager/types.py
+++ b/partitionmanager/types.py
@@ -106,11 +106,11 @@ class SqlQuery(str):
 
         if "?" not in query_string:
             raise argparse.ArgumentTypeError(
-                f"[{query_string}] has no substituion variable '?'"
+                f"[{query_string}] has no substitution variable '?'"
             )
         if query_string.count("?") > 1:
             raise argparse.ArgumentTypeError(
-                f"[{query_string}] has more than one substituion variable '?'"
+                f"[{query_string}] has more than one substitution variable '?'"
             )
 
         if not query_string.upper().startswith("SELECT "):

--- a/partitionmanager/types.py
+++ b/partitionmanager/types.py
@@ -32,7 +32,7 @@ class Table:
         self.name = SqlInput(name)
         self.retention = None
         self.partition_period = None
-        self.insertion_date_query = None
+        self.earliest_utc_timestamp_query = None
 
     def set_retention(self, ret):
         """
@@ -52,14 +52,14 @@ class Table:
         self.partition_period = dur
         return self
 
-    def set_insertion_date_query(self, query):
+    def set_earliest_utc_timestamp_query(self, query):
         if not isinstance(query, SqlQuery):
             raise ValueError("Must be a SqlQuery")
-        self.insertion_date_query = query
+        self.earliest_utc_timestamp_query = query
 
     @property
     def has_date_query(self):
-        return self.insertion_date_query is not None
+        return self.earliest_utc_timestamp_query is not None
 
     def __str__(self):
         return f"Table {self.name}"

--- a/partitionmanager/types.py
+++ b/partitionmanager/types.py
@@ -32,6 +32,7 @@ class Table:
         self.name = SqlInput(name)
         self.retention = None
         self.partition_period = None
+        self.insertion_date_query = None
 
     def set_retention(self, ret):
         """
@@ -51,13 +52,22 @@ class Table:
         self.partition_period = dur
         return self
 
+    def set_insertion_date_query(self, query):
+        if not isinstance(query, SqlQuery):
+            raise ValueError("Must be a SqlQuery")
+        self.insertion_date_query = query
+
+    @property
+    def has_date_query(self):
+        return self.insertion_date_query is not None
+
     def __str__(self):
         return f"Table {self.name}"
 
 
 class SqlInput(str):
     """
-    Class which wraps a string only if the string is safe to use within a
+    Class which wraps a string or number only if it is safe to use within a
     single SQL statement.
     """
 
@@ -66,12 +76,62 @@ class SqlInput(str):
     def __new__(cls, *args):
         if len(args) != 1:
             raise argparse.ArgumentTypeError(f"{args} is not a single argument")
-        if not SqlInput.valid_form.match(args[0]):
+        if not isinstance(args[0], int) and not SqlInput.valid_form.match(args[0]):
             raise argparse.ArgumentTypeError(f"{args[0]} is not a valid SQL identifier")
         return super().__new__(cls, args[0])
 
     def __repr__(self):
         return str(self)
+
+
+class SqlQuery(str):
+    """
+    Class which loosely enforces that there's a single SQL SELECT statement to run.
+    """
+
+    forbidden_terms = ["UPDATE ", "INSERT ", "DELETE "]
+
+    def __new__(cls, *args):
+        if len(args) != 1:
+            raise argparse.ArgumentTypeError(f"{args} is not a single argument")
+        query_string = args[0].strip()
+        if not query_string.endswith(";"):
+            raise argparse.ArgumentTypeError(
+                f"[{query_string}] does not end with a ';'"
+            )
+        if query_string.count(";") > 1:
+            raise argparse.ArgumentTypeError(
+                f"[{query_string}] has more than one statement"
+            )
+
+        if "?" not in query_string:
+            raise argparse.ArgumentTypeError(
+                f"[{query_string}] has no substituion variable '?'"
+            )
+        if query_string.count("?") > 1:
+            raise argparse.ArgumentTypeError(
+                f"[{query_string}] has more than one substituion variable '?'"
+            )
+
+        if not query_string.upper().startswith("SELECT "):
+            raise argparse.ArgumentTypeError(
+                f"[{query_string}] is not a SELECT statement"
+            )
+        for term in SqlQuery.forbidden_terms:
+            if term in query_string.upper():
+                raise argparse.ArgumentTypeError(
+                    f"[{query_string}] has a forbidden term [{term}]"
+                )
+
+        return super().__new__(cls, query_string)
+
+    def __repr__(self):
+        return str(self)
+
+    def get_statement_with_argument(self, arg):
+        if not isinstance(arg, SqlInput):
+            raise argparse.ArgumentTypeError("Must be a SqlInput")
+        return str(self).replace("?", str(arg))
 
 
 def to_sql_url(urlstring):
@@ -208,6 +268,10 @@ class Position:
     def as_list(self):
         """Return a copy of the list of identifiers representing this position"""
         return self._position.copy()
+
+    def as_sql_input(self):
+        """Return the position as an array of SqlInput objects"""
+        return [SqlInput(p) for p in self._position]
 
     def __len__(self):
         return len(self._position)
@@ -348,8 +412,8 @@ class InstantPartition(PositionPartition):
     of the rate calculation itself.
     """
 
-    def __init__(self, now, position_in):
-        super().__init__("Instant")
+    def __init__(self, name, now, position_in):
+        super().__init__(name)
         self._instant = now
         self._position.set_position(position_in)
 

--- a/partitionmanager/types_test.py
+++ b/partitionmanager/types_test.py
@@ -169,12 +169,12 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(timedelta(days=30), r)
 
         with self.assertRaises(ValueError):
-            t.set_insertion_date_query("col")
+            t.set_earliest_utc_timestamp_query("col")
         with self.assertRaises(ValueError):
-            t.set_insertion_date_query(None)
+            t.set_earliest_utc_timestamp_query(None)
         self.assertFalse(t.has_date_query)
 
-        t.set_insertion_date_query(
+        t.set_earliest_utc_timestamp_query(
             SqlQuery("SELECT not_before FROM table WHERE id = ?;")
         )
         self.assertTrue(t.has_date_query)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="mariadb-sequential-partition-manager",
-    version="0.2.5",
+    version="0.3.0",
     description="Manage DB partitions based on sequential IDs",
     long_description="Manage MariaDB Partitions based on sequential IDs",
     classifiers=[


### PR DESCRIPTION
Fixes #30

This commit limits the functionality to tables with single-column primary keys.