### PR TITLE
Retention-based Partition Dropping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Linting Tools
       run: |
         python -m pip install --upgrade pip
-        pip install --user pylint==2.6.0
+        pip install --user pylint==2.17.7
         pip install --user black~=22.3
         pip install --user flake8~=4.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         pip install --user pylint==2.17.7
         pip install --user black~=22.3
         pip install --user flake8~=4.0
+        pip install --user pytest
 
     - name: Install Partition Manager
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
   hooks:
     - id: flake8
 - repo: https://github.com/PyCQA/pylint
-  rev: pylint-2.6.0
+  rev: v2.17.7
   hooks:
   -   id: pylint
       args:

--- a/partitionmanager/cli.py
+++ b/partitionmanager/cli.py
@@ -320,15 +320,9 @@ def do_partition(conf):
                 duration = table.partition_period
 
             log.info(f"Evaluating {table} (duration={duration})")
-
-            positions = pm_tap.get_current_positions(
-                conf.dbcmd, table, map_data["range_cols"]
+            cur_pos = partitionmanager.database_helpers.get_position_of_table(
+                conf.dbcmd, table, map_data
             )
-
-            log.info(f"{table} (pos={positions})")
-
-            cur_pos = partitionmanager.types.Position()
-            cur_pos.set_position([positions[col] for col in map_data["range_cols"]])
 
             sql_cmds = pm_tap.get_pending_sql_reorganize_partition_commands(
                 database=conf.dbcmd,

--- a/partitionmanager/cli.py
+++ b/partitionmanager/cli.py
@@ -479,11 +479,11 @@ def do_find_drops_for_tables(conf):
         log = logging.getLogger(f"do_find_drops_for_tables:{table.name}")
 
         if not table.has_date_query:
-            log.debug(f"Cannot process {table}: no date query specified")
+            log.warning(f"Cannot process {table}: no date query specified")
             continue
 
         if not table.retention_period:
-            log.debug(f"Cannot process {table}: no retention specified")
+            log.warning(f"Cannot process {table}: no retention specified")
             continue
 
         try:

--- a/partitionmanager/cli_test.py
+++ b/partitionmanager/cli_test.py
@@ -224,11 +224,9 @@ partitionmanager:
                 [
                     "INFO:partition:Evaluating Table partitioned_last_week "
                     "(duration=7 days, 0:00:00)",
-                    "INFO:partition:Table partitioned_last_week (pos={'id': 150})",
                     "DEBUG:partition:Table partitioned_last_week has no pending SQL updates.",
                     "INFO:partition:Evaluating Table partitioned_yesterday "
                     "(duration=7 days, 0:00:00)",
-                    "INFO:partition:Table partitioned_yesterday (pos={'id': 150})",
                     "DEBUG:partition:Table partitioned_yesterday has no pending SQL updates.",
                 ]
             ),

--- a/partitionmanager/database_helpers.py
+++ b/partitionmanager/database_helpers.py
@@ -1,0 +1,72 @@
+"""
+Helper functions for database operations
+"""
+
+from datetime import datetime, timezone
+import logging
+
+import partitionmanager.table_append_partition as pm_tap
+import partitionmanager.types
+
+
+def get_position_of_table(database, table, map_data):
+    """Returns a Position of the table at the current moment."""
+
+    pos_list = pm_tap.get_current_positions(database, table, map_data["range_cols"])
+
+    cur_pos = partitionmanager.types.Position()
+    cur_pos.set_position([pos_list[col] for col in map_data["range_cols"]])
+
+    return cur_pos
+
+
+def calculate_exact_timestamp_via_query(database, table, position_partition):
+    """Calculates the exact timestamp of a PositionPartition.
+
+    raises ValueError if the position is incalculable
+    """
+
+    log = logging.getLogger(f"calculate_exact_timestamp_via_query:{table.name}")
+
+    if not table.has_date_query:
+        raise ValueError("Table has no defined date query")
+
+    if not isinstance(position_partition, partitionmanager.types.PositionPartition):
+        raise ValueError("Only PositionPartitions are supported")
+
+    if len(position_partition.position) != 1:
+        raise ValueError(
+            "This method is only valid for single-column partitions right now"
+        )
+    arg = position_partition.position.as_sql_input()[0]
+
+    sql_select_cmd = table.earliest_utc_timestamp_query.get_statement_with_argument(arg)
+    log.debug(
+        "Executing %s to derive partition %s at position %s",
+        sql_select_cmd,
+        position_partition.name,
+        position_partition.position,
+    )
+
+    start = datetime.now()
+    exact_time_result = database.run(sql_select_cmd)
+    end = datetime.now()
+
+    if not len(exact_time_result) == 1:
+        raise partitionmanager.types.NoExactTimeException("No exact timestamp result")
+    if not len(exact_time_result[0]) == 1:
+        raise partitionmanager.types.NoExactTimeException(
+            "Unexpected row count for the timestamp result"
+        )
+    for key, value in exact_time_result[0].items():
+        exact_time = datetime.fromtimestamp(value, tz=timezone.utc)
+        break
+
+    log.debug(
+        "Exact time of %s returned for %s at position %s, query took %s",
+        exact_time,
+        position_partition.name,
+        position_partition.position,
+        (end - start),
+    )
+    return exact_time

--- a/partitionmanager/database_helpers.py
+++ b/partitionmanager/database_helpers.py
@@ -56,7 +56,7 @@ def calculate_exact_timestamp_via_query(database, table, position_partition):
         raise partitionmanager.types.NoExactTimeException("No exact timestamp result")
     if not len(exact_time_result[0]) == 1:
         raise partitionmanager.types.NoExactTimeException(
-            "Unexpected row count for the timestamp result"
+            "Unexpected column count for the timestamp result"
         )
     for key, value in exact_time_result[0].items():
         exact_time = datetime.fromtimestamp(value, tz=timezone.utc)

--- a/partitionmanager/database_helpers_test.py
+++ b/partitionmanager/database_helpers_test.py
@@ -1,0 +1,79 @@
+import unittest
+
+from .database_helpers import get_position_of_table, calculate_exact_timestamp_via_query
+
+from .types import (
+    DatabaseCommand,
+    Table,
+    SqlInput,
+    SqlQuery,
+    PositionPartition,
+)
+
+
+class MockDatabase(DatabaseCommand):
+    def __init__(self):
+        self._responses = list()
+        self.num_queries = 0
+
+    def add_response(self, expected, response):
+        self._responses.append({"expected": expected, "response": response})
+
+    def run(self, cmd):
+        self.num_queries += 1
+        if not self._responses:
+            raise Exception(f"No mock responses available for cmd [{cmd}]")
+
+        r = self._responses.pop()
+        if r["expected"] in cmd:
+            return r["response"]
+
+        raise Exception(f"Received command [{cmd}] and expected [{r['expected']}]")
+
+    def db_name(self):
+        return SqlInput("the-database")
+
+
+class TestDatabaseHelpers(unittest.TestCase):
+    def test_position_of_table(self):
+        db = MockDatabase()
+        db.add_response("SELECT id FROM `burgers` ORDER BY", [{"id": 90210}])
+
+        table = Table("burgers")
+        data = {"range_cols": ["id"]}
+
+        pos = get_position_of_table(db, table, data)
+        self.assertEqual(pos.as_list(), [90210])
+
+    def test_exact_timestamp_no_query(self):
+        db = MockDatabase()
+        db.add_response("SELECT id FROM `burgers` ORDER BY", [{"id": 42}])
+
+        table = Table("burgers")
+        self.assertFalse(table.has_date_query)
+
+        pos = PositionPartition("p_start")
+        pos.set_position([42])
+
+        with self.assertRaises(ValueError):
+            calculate_exact_timestamp_via_query(db, table, pos)
+
+    def test_exact_timestamp(self):
+        db = MockDatabase()
+        db.add_response(
+            "SELECT UNIX_TIMESTAMP(`cooked`)", [{"UNIX_TIMESTAMP": 17541339060}]
+        )
+
+        table = Table("burgers")
+        table.set_earliest_utc_timestamp_query(
+            SqlQuery(
+                "SELECT UNIX_TIMESTAMP(`cooked`) FROM `orders` "
+                "WHERE `type` = \"burger\" AND `id` > '?' ORDER BY `id` ASC LIMIT 1;"
+            )
+        )
+
+        pos = PositionPartition("p_start")
+        pos.set_position([150])
+
+        ts = calculate_exact_timestamp_via_query(db, table, pos)
+        self.assertEqual(f"{ts}", "2525-11-11 18:11:00+00:00")

--- a/partitionmanager/database_helpers_test.py
+++ b/partitionmanager/database_helpers_test.py
@@ -17,7 +17,7 @@ class MockDatabase(DatabaseCommand):
         self.num_queries = 0
 
     def add_response(self, expected, response):
-        self._responses.append({"expected": expected, "response": response})
+        self._responses.insert(0, {"expected": expected, "response": response})
 
     def run(self, cmd):
         self.num_queries += 1

--- a/partitionmanager/dropper.py
+++ b/partitionmanager/dropper.py
@@ -13,11 +13,12 @@ def _drop_statement(table, partition_list):
 
     log = logging.getLogger("get_droppable_partitions")
 
+    if not partition_list:
+        raise ValueError("Partition list may not be empty")
+
     partitions = ",".join(map(lambda x: f"`{x.name}`", partition_list))
 
-    alter_cmd = (
-        f"ALTER TABLE `{table.name}` " f"DROP PARTITION IF EXISTS {partitions} ;"
-    )
+    alter_cmd = f"ALTER TABLE `{table.name}` " f"DROP PARTITION IF EXISTS {partitions};"
 
     log.debug("Yielding %s", alter_cmd)
 

--- a/partitionmanager/dropper.py
+++ b/partitionmanager/dropper.py
@@ -1,0 +1,110 @@
+"""
+Determine which partitions can be dropped.
+"""
+
+import logging
+
+import partitionmanager.types
+import partitionmanager.tools
+
+
+def _drop_statement(table, partition_list):
+    """Generate an ALTER TABLE statement to drop these partitions."""
+
+    log = logging.getLogger("get_droppable_partitions")
+
+    partitions = ",".join(map(lambda x: f"`{x.name}`", partition_list))
+
+    alter_cmd = (
+        f"ALTER TABLE `{table.name}` " f"DROP PARTITION IF EXISTS {partitions} ;"
+    )
+
+    log.debug("Yielding %s", alter_cmd)
+
+    return alter_cmd
+
+
+def get_droppable_partitions(
+    database, partitions, current_position, current_timestamp, table
+):
+    """Return a dictionary of partitions which can be dropped and why."""
+    log = logging.getLogger("get_droppable_partitions")
+    results = {}
+    droppable = []
+
+    if not table.retention_period:
+        raise ValueError(f"{table.name} does not have a retention period set")
+
+    if not partitions:
+        return results
+
+    for partition, next_partition in partitionmanager.tools.pairwise(partitions):
+        if next_partition >= current_position:
+            log.debug(
+                "Stopping at %s because current position %s indicates "
+                "subsequent partition is empty",
+                partition,
+                current_position,
+            )
+            break
+
+        if isinstance(next_partition, partitionmanager.types.MaxValuePartition):
+            log.debug("Stopping at %s because we can't handle MaxValuePartitions.")
+            break
+
+        assert isinstance(next_partition, partitionmanager.types.PositionPartition)
+
+        approx_size = 0
+        for a, b in zip(
+            next_partition.position.as_list(), partition.position.as_list()
+        ):
+            approx_size += a - b
+
+        try:
+            start_time = (
+                partitionmanager.database_helpers.calculate_exact_timestamp_via_query(
+                    database, table, partition
+                )
+            )
+            end_time = (
+                partitionmanager.database_helpers.calculate_exact_timestamp_via_query(
+                    database, table, next_partition
+                )
+            )
+
+            oldest_age = current_timestamp - start_time
+            youngest_age = current_timestamp - end_time
+
+            if youngest_age > table.retention_period:
+                results[partition.name] = {
+                    "oldest_time": f"{start_time}",
+                    "youngest_time": f"{end_time}",
+                    "oldest_position": partition.position,
+                    "youngest_position": next_partition.position,
+                    "oldest_age": f"{oldest_age}",
+                    "youngest_age": f"{youngest_age}",
+                    "approx_size": approx_size,
+                }
+                droppable.append(partition)
+        except partitionmanager.types.NoExactTimeException:
+            log.warning(
+                "Couldn't determine exact times for %s.%s, it is probably droppable too.",
+                table,
+                partition,
+            )
+
+            results[partition.name] = {
+                "oldest_time": "unable to determine",
+                "youngest_time": "unable to determine",
+                "oldest_position": partition.position,
+                "youngest_position": next_partition.position,
+                "oldest_age": "unable to determine",
+                "youngest_age": "unable to determine",
+                "approx_size": approx_size,
+            }
+            droppable.append(partition)
+
+    if droppable:
+        results["drop_query"] = _drop_statement(table, droppable)
+
+    return results

--- a/partitionmanager/dropper.py
+++ b/partitionmanager/dropper.py
@@ -39,6 +39,9 @@ def get_droppable_partitions(
     if not partitions:
         return results
 
+    if sorted(partitions) != partitions:
+        raise ValueError(f"Supplied partitions are not correctly sorted: {partitions}")
+
     for partition, next_partition in partitionmanager.tools.pairwise(partitions):
         if next_partition >= current_position:
             log.debug(

--- a/partitionmanager/dropper_test.py
+++ b/partitionmanager/dropper_test.py
@@ -1,0 +1,118 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from .dropper import _drop_statement, get_droppable_partitions
+from .types import (
+    DatabaseCommand,
+    Table,
+    SqlInput,
+    SqlQuery,
+    PositionPartition,
+)
+from .types_test import mkPPart, mkTailPart, mkPos
+
+
+class MockDatabase(DatabaseCommand):
+    def __init__(self):
+        self._responses = list()
+        self.num_queries = 0
+
+    def add_response(self, expected, response):
+        self._responses.insert(0, {"expected": expected, "response": response})
+
+    def run(self, cmd):
+        self.num_queries += 1
+        if not self._responses:
+            raise Exception(f"No mock responses available for cmd [{cmd}]")
+
+        r = self._responses.pop()
+        if r["expected"] in cmd:
+            return r["response"]
+
+        raise Exception(f"Received command [{cmd}] and expected [{r['expected']}]")
+
+    def db_name(self):
+        return SqlInput("the-database")
+
+
+class TestDropper(unittest.TestCase):
+    def test_drop_statement_empty(self):
+        table = Table("burgers")
+        parts = []
+        with self.assertRaises(ValueError):
+            _drop_statement(table, parts)
+
+    def test_drop_statement(self):
+        table = Table("burgers")
+        parts = [PositionPartition("p_start")]
+        self.assertEqual(
+            _drop_statement(table, parts),
+            "ALTER TABLE `burgers` DROP PARTITION IF EXISTS `p_start`;",
+        )
+
+    def test_get_droppable_partitions_invalid_config(self):
+        database = MockDatabase()
+        table = Table("burgers")
+        partitions = [PositionPartition("p_start")]
+        current_timestamp = datetime(2021, 1, 1, tzinfo=timezone.utc)
+        current_position = PositionPartition("p_20210102").set_position([10])
+
+        with self.assertRaises(ValueError):
+            get_droppable_partitions(
+                database, partitions, current_position, current_timestamp, table
+            )
+
+    def test_get_droppable_partitions(self):
+        database = MockDatabase()
+        database.add_response("WHERE `id` > '100'", [{"UNIX_TIMESTAMP": 1621468800}])
+        database.add_response("WHERE `id` > '200'", [{"UNIX_TIMESTAMP": 1622073600}])
+        database.add_response("WHERE `id` > '200'", [{"UNIX_TIMESTAMP": 1622073600}])
+        database.add_response("WHERE `id` > '300'", [{"UNIX_TIMESTAMP": 1622678400}])
+        database.add_response("WHERE `id` > '300'", [{"UNIX_TIMESTAMP": 1622678400}])
+        database.add_response("WHERE `id` > '400'", [{"UNIX_TIMESTAMP": 1623283200}])
+        database.add_response("WHERE `id` > '400'", [{"UNIX_TIMESTAMP": 1623283200}])
+        database.add_response("WHERE `id` > '500'", [{"UNIX_TIMESTAMP": 1623888000}])
+
+        table = Table("burgers")
+        table.set_earliest_utc_timestamp_query(
+            SqlQuery(
+                "SELECT UNIX_TIMESTAMP(`cooked`) FROM `orders` "
+                "WHERE `id` > '?' ORDER BY `id` ASC LIMIT 1;"
+            )
+        )
+        current_timestamp = datetime(2021, 7, 1, tzinfo=timezone.utc)
+
+        partitions = [
+            mkPPart("1", 100),
+            mkPPart("2", 200),
+            mkPPart("3", 300),
+            mkPPart("4", 400),
+            mkPPart("5", 500),
+            mkPPart("6", 600),
+            mkTailPart("z"),
+        ]
+        current_position = mkPos(340)
+
+        table.set_retention_period(timedelta(days=2))
+        results = get_droppable_partitions(
+            database, partitions, current_position, current_timestamp, table
+        )
+        self.assertEqual(
+            results["drop_query"],
+            "ALTER TABLE `burgers` DROP PARTITION IF EXISTS `1`,`2`;",
+        )
+        self.assertEqual(results["1"]["oldest_time"], "2021-05-20 00:00:00+00:00")
+        self.assertEqual(results["1"]["youngest_time"], "2021-05-27 00:00:00+00:00")
+        self.assertEqual(results["1"]["oldest_position"].as_list(), [100])
+        self.assertEqual(results["1"]["youngest_position"].as_list(), [200])
+        self.assertEqual(results["1"]["oldest_age"], "42 days, 0:00:00")
+        self.assertEqual(results["1"]["youngest_age"], "35 days, 0:00:00")
+        self.assertEqual(results["1"]["approx_size"], 100)
+
+        self.assertEqual(results["2"]["oldest_time"], "2021-05-27 00:00:00+00:00")
+        self.assertEqual(results["2"]["youngest_time"], "2021-06-03 00:00:00+00:00")
+        self.assertEqual(results["2"]["oldest_position"].as_list(), [200])
+        self.assertEqual(results["2"]["youngest_position"].as_list(), [300])
+        self.assertEqual(results["2"]["oldest_age"], "35 days, 0:00:00")
+        self.assertEqual(results["2"]["youngest_age"], "28 days, 0:00:00")
+        self.assertEqual(results["2"]["approx_size"], 100)

--- a/partitionmanager/types.py
+++ b/partitionmanager/types.py
@@ -30,17 +30,17 @@ class Table:
 
     def __init__(self, name):
         self.name = SqlInput(name)
-        self.retention = None
+        self.retention_period = None
         self.partition_period = None
         self.earliest_utc_timestamp_query = None
 
-    def set_retention(self, ret):
+    def set_retention_period(self, ret):
         """
         Sets the retention period as a timedelta for this table
         """
         if not isinstance(ret, timedelta):
             raise ValueError("Must be a timedelta")
-        self.retention = ret
+        self.retention_period = ret
         return self
 
     def set_partition_period(self, dur):
@@ -350,6 +350,9 @@ class PositionPartition(_Partition):
                 return True
         return False
 
+    def __ge__(self, other):
+        return not self < other
+
     def __eq__(self, other):
         if isinstance(other, PositionPartition):
             return self.name == other.name and self._position == other.position
@@ -398,6 +401,9 @@ class MaxValuePartition(_Partition):
                 )
             return False
         return ValueError()
+
+    def __ge__(self, other):
+        return not self < other
 
     def __eq__(self, other):
         if isinstance(other, MaxValuePartition):
@@ -609,3 +615,7 @@ class NoEmptyPartitionsAvailableException(Exception):
 
 class DatabaseCommandException(Exception):
     """Raised if the database command failed."""
+
+
+class NoExactTimeException(Exception):
+    """Raised if there's no exact time available for this partition."""

--- a/partitionmanager/types_test.py
+++ b/partitionmanager/types_test.py
@@ -1,5 +1,6 @@
 import argparse
 import unittest
+import pytest
 from datetime import datetime, timedelta, timezone
 from .types import (
     ChangePlannedPartition,
@@ -183,6 +184,10 @@ class TestTypes(unittest.TestCase):
             SqlQuery("SELECT not_before FROM table WHERE id = ?;")
         )
         self.assertTrue(t.has_date_query)
+
+    def test_invalid_timedelta_string(self):
+        with pytest.raises(AttributeError):
+            assert timedelta_from_dict("30s")
 
     def test_changed_partition(self):
         with self.assertRaises(ValueError):

--- a/partitionmanager/types_test.py
+++ b/partitionmanager/types_test.py
@@ -153,6 +153,11 @@ class TestTypes(unittest.TestCase):
             timedelta(days=9),
         )
 
+        self.assertEqual(
+            Table("a").set_retention_period(timedelta(days=9)).retention_period,
+            timedelta(days=9),
+        )
+
         with self.assertRaises(argparse.ArgumentTypeError):
             timedelta_from_dict({"something": 1})
 

--- a/partitionmanager/types_test.py
+++ b/partitionmanager/types_test.py
@@ -146,7 +146,7 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(type(Table("name").name), SqlInput)
 
         t = Table("t")
-        self.assertEqual(None, t.retention)
+        self.assertEqual(None, t.retention_period)
 
         self.assertEqual(
             Table("a").set_partition_period(timedelta(days=9)).partition_period,


### PR DESCRIPTION
Determine which partitions are wholly outside of the configured `retention_period` for a given table and emit commands to drop them.

I'd just like to write for posterity that this is getting real hacky, even more so now with this branch rebased on top of the last year's worth of fixes.

To give just a hint of the deltas of the current version vs. what it was designed to do:

Partman gathers the Partition Table of each table, and attaches to each Partition the beginning and end positions, and then knowledge of how to derive the beginning and end _timestamps._ However, we know now that because MariaDB selects Partitions based on an incoming row matching _any_ part of a partition, the partition offsets in the partition table are just guideposts. In reality, one must `SELECT ... FROM table PARTITION(partition_name) ...` to have actual truth of what the positions of the beginning and end of the partition. Deriving it from the table is dangerous, because it works until it doesn't, and that's where #64 comes from.

Partman also then assumed in the beginning that getting the start and end timestamps for a partition could come from the _partition names_, which leads to all these `ALTER` statements to keep the partition names roughly true. But that's hard to keep up with, and if we have a narrow set of partitions it ends up with giving very few data points from which to calculate a rate of change. But all the methods in Partman to calculate this stuff does so from the perspective of "calculate the rate of change of these _partitions_", but in reality we shouldn't care about the partitions at all. We should instead use the primary key, select the min, max, and then sample points between the two to get a better rate of change. Basically, we assumed in the beginning we could do this without `earliest_utc_timestamp_query`, but now that's basically mandatory. And we should use _that_.

And these decisions are baked into the myriad `Partition` types in `types.py`, which are all far too complicated.

Anyway, this thing needs a rewrite to become much simpler.
