### PR TITLE
Correct multi-column key partition ordering

### DIFF
--- a/partitionmanager/table_append_partition_test.py
+++ b/partitionmanager/table_append_partition_test.py
@@ -358,7 +358,11 @@ class TestPartitionAlgorithm(unittest.TestCase):
                 [mkPPart("a", 10, 10), mkPPart("b", 20, 20), mkTailPart("z", count=2)],
                 mkPos(19, 500),
             ),
-            ([mkPPart("a", 10, 10)], mkPPart("b", 20, 20), [mkTailPart("z", count=2)]),
+            (
+                [mkPPart("a", 10, 10), mkPPart("b", 20, 20)],
+                mkTailPart("z", count=2),
+                [],
+            ),
         )
 
     def test_get_position_increase_per_day(self):

--- a/partitionmanager/types.py
+++ b/partitionmanager/types.py
@@ -343,10 +343,12 @@ class PositionPartition(_Partition):
                 f"Expected {len(self._position)} columns but partition has {other_position_list}."
             )
 
+        # If ALL of v_mine >= v_other, then self is greater than other
+        # If ANY of v_mine < v_other, then self is less than other
         for v_mine, v_other in zip(self._position.as_list(), other_position_list):
-            if v_mine >= v_other:
-                return False
-        return True
+            if v_mine < v_other:
+                return True
+        return False
 
     def __eq__(self, other):
         if isinstance(other, PositionPartition):

--- a/partitionmanager/types_test.py
+++ b/partitionmanager/types_test.py
@@ -345,17 +345,29 @@ class TestPartition(unittest.TestCase):
         with self.assertRaises(UnexpectedPartitionException):
             mkPPart("a", 10, 10) < mkTailPart("b", count=1)
 
-        self.assertFalse(mkPPart("a", 10, 10) < mkPPart("b", 11, 10))
-        self.assertFalse(mkPPart("a", 10, 10) < mkPPart("b", 10, 11))
+        self.assertTrue(mkPPart("a", 10, 10) < mkPPart("b", 11, 10))
+        self.assertTrue(mkPPart("a", 10, 10) < mkPPart("b", 10, 11))
         self.assertLess(mkPPart("a", 10, 10), mkPPart("b", 11, 11))
-        self.assertFalse(mkPPart("a", 10, 10) < [10, 11])
-        self.assertFalse(mkPPart("a", 10, 10) < [11, 10])
+        self.assertTrue(mkPPart("a", 10, 10) < [10, 11])
+        self.assertTrue(mkPPart("a", 10, 10) < [11, 10])
         self.assertLess(mkPPart("a", 10, 10), [11, 11])
 
         with self.assertRaises(UnexpectedPartitionException):
             mkPPart("a", 10, 10) < mkPPart("b", 11, 11, 11)
         with self.assertRaises(UnexpectedPartitionException):
             mkPPart("a", 10, 10, 10) < mkPPart("b", 11, 11)
+
+    def test_partition_tuple_ordering(self):
+        cur_pos = mkPPart("current_pos", 8236476764, 6096376984)
+        p_20220525 = mkPPart("p_20220525", 2805308158, 2682458996)
+        p_20220611 = mkPPart("p_20220611", 7882495694, 7856340600)
+        p_20230519 = mkPPart("p_20230519", 10790547177, 11048018089)
+        p_20230724 = mkPPart("p_20230724", 95233456870, 97348306298)
+
+        self.assertGreater(cur_pos, p_20220525)
+        self.assertGreater(cur_pos, p_20220611)
+        self.assertLess(cur_pos, p_20230519)
+        self.assertLess(cur_pos, p_20230724)
 
     def test_instant_partition(self):
         now = datetime.utcnow()


### PR DESCRIPTION
To quote from the documentation:

> With RANGE COLUMNS, a row matches a partition if all row values are less
> than specified values. The first partition that matches row values will be
> used.

Previously, with `RANGE COLUMNS`, partition-manager got this logic backward, which led to partitions being considered "unfilled" and candidates for rename which actually had data in them.

Fixes #60