### PR TITLE
Prevent potential supply chain attack by referencing a commit rather than @latest in GH action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
           nfpm package -p deb --target "nfpm-pkg/"
 
       - name: "Publish release"
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: "marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "${{ steps.get_version.outputs.version }}"


### PR DESCRIPTION
The commit referenced below is the [latest available](https://github.com/marvinpinto/action-automatic-releases/commit/d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1).

Relevant Github [docs](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions)
