### PR TITLE
setuptools-py2cfg: setup.py --> setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,33 @@
+[metadata]
+name = mariadb_sequential_partition_manager
+version = 0.3.7
+description = Manage DB partitions based on sequential IDs
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = http://github.com/letsencrypt/mariadb-sequential-partition-manager
+author = J.C. Jones
+author_email = jc@letsencrypt.org
+license = MPL-2.0
+license_files = LICENSE.txt
+classifiers =
+    Development Status :: 4 - Beta
+    License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+keywords = database
+
+[options]
+packages = partitionmanager
+install_requires =
+    pyyaml
+python_requires = >=3.8
+include_package_data = True
+zip_safe = False
+
+[options.entry_points]
+console_scripts =
+    partition-manager=partitionmanager.cli:main
+
+[options.extras_require]
+pymysql =
+    PyMySQL>=1.0.2

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,4 @@
 from setuptools import setup
 
 
-setup(
-    name="mariadb-sequential-partition-manager",
-    version="0.3.7",
-    description="Manage DB partitions based on sequential IDs",
-    long_description="Manage MariaDB Partitions based on sequential IDs",
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
-        "Programming Language :: Python :: 3",
-    ],
-    keywords="database",
-    url="http://github.com/letsencrypt/mariadb-sequential-partition-manager",
-    author="J.C. Jones",
-    author_email="jc@letsencrypt.org",
-    license="Mozilla Public License 2.0 (MPL 2.0)",
-    zip_safe=False,
-    include_package_data=True,
-    python_requires=">=3.6",
-    install_requires=["pyyaml"],
-    extras_require={"pymysql": ["PyMySQL >= 1.0.2"]},
-    packages=["partitionmanager"],
-    entry_points={"console_scripts": ["partition-manager=partitionmanager.cli:main"]},
-    options={"build_scripts": {"executable": "/usr/bin/env python3"}},
-)
+setup()


### PR DESCRIPTION
Step 1 of 2 in fixing #66 

Run [`setuptools-py2cfg`](https://pypi.org/project/setuptools-py2cfg) to migrate from `setup.py` --> `setup.cfg`.
Run [`setup-cfg-fmt setup.cfg`](https://pypi.org/project/setup-cfg-fmt/) to validate and format the result.

Step 2 will involve the use of [`ini2toml`](https://pypi.org/project/ini2toml) and [`validate-pyproject`](validate-pyproject).