### PR TITLE
Replace black and flake8 with ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-# See http://pep8.readthedocs.io/en/latest/intro.html#configuration
-ignore = E121, E123, E126, E129, E133, E203, E226, E241, E242, E704, W503, E402, E741
-max-line-length = 99

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 
     - name: Install Linting Tools
       run: |
         python -m pip install --upgrade pip
-        pip install --user pylint==3.1.0
-        pip install --user black~=23.9.1
-        pip install --user flake8~=6.1.0
-        pip install --user pytest
+        pip install --user pylint==3.1.0 pytest ruff
 
     - name: Install Partition Manager
       run: |
@@ -30,21 +27,21 @@ jobs:
       run: |
         python -m pylint -E partitionmanager
 
-    - name: Checking format with Black
+    - name: Checking format with Ruff
       run: |
-        python -m black --check .
+        python -m ruff format .
 
-    - name: Checking format with Flake8
+    - name: Lint Python code with Ruff
       run: |
-        python -m flake8
+        python -m ruff --output-format=github
 
   test:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Install Partition Manager

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
     - id: check-ast
     - id: check-merge-conflict
@@ -8,14 +8,13 @@ repos:
     - id: end-of-file-fixer
     - id: requirements-txt-fixer
     - id: trailing-whitespace
-- repo:  https://github.com/psf/black
-  rev: "23.9.1"
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.2.2
   hooks:
-    - id: black
-- repo: https://github.com/pycqa/flake8
-  rev: "6.1.0"
-  hooks:
-    - id: flake8
+    - id: ruff
+    # - id: ruff-format
+
 - repo: https://github.com/PyCQA/pylint
   rev: v3.1.0
   hooks:
@@ -26,6 +25,8 @@ repos:
       - PyMySQL
       - pyyaml
       - pytest
+      - setuptools
+
 - repo: local
   hooks:
     - id: pytest

--- a/partitionmanager/database_helpers.py
+++ b/partitionmanager/database_helpers.py
@@ -58,7 +58,7 @@ def calculate_exact_timestamp_via_query(database, table, position_partition):
         raise partitionmanager.types.NoExactTimeException(
             "Unexpected column count for the timestamp result"
         )
-    for key, value in exact_time_result[0].items():
+    for value in exact_time_result[0].values():
         exact_time = datetime.fromtimestamp(value, tz=timezone.utc)
         break
 

--- a/partitionmanager/migrate.py
+++ b/partitionmanager/migrate.py
@@ -175,8 +175,7 @@ def _generate_sql_copy_commands(
     yield f"\tPARTITION {max_val_part.name} VALUES LESS THAN {max_val_string}"
     yield ");"
 
-    for command in alter_commands_iter:
-        yield command
+    yield from alter_commands_iter
 
     cols = set(columns)
 
@@ -214,9 +213,11 @@ def _generate_sql_copy_commands(
     ):
         yield line
 
-    yield "\t\tWHERE " + " AND ".join(
-        _trigger_column_copies(map_data["range_cols"])
-    ) + ";"
+    yield (
+        "\t\tWHERE "
+        + " AND ".join(_trigger_column_copies(map_data["range_cols"]))
+        + ";"
+    )
 
     return
 

--- a/partitionmanager/stats_test.py
+++ b/partitionmanager/stats_test.py
@@ -46,7 +46,7 @@ class TestStatistics(unittest.TestCase):
     def test_statistics_weekly_partitions_year(self):
         parts = list()
         base = datetime(2020, 5, 20, tzinfo=timezone.utc)
-        for w in range(0, 52):
+        for w in range(52):
             partName = f"p_{base + timedelta(weeks=w):%Y%m%d}"
             parts.append(mkPPart(partName, w * 1024))
         parts.append(MaxValuePartition(f"p_{base + timedelta(weeks=52):%Y%m%d}", 1))

--- a/partitionmanager/table_append_partition.py
+++ b/partitionmanager/table_append_partition.py
@@ -107,13 +107,13 @@ def _parse_partition_map(rows):
 
     options = rows[0]
 
-    for l in options["Create Table"].split("\n"):
-        range_match = partition_range.match(l)
+    for line in options["Create Table"].split("\n"):
+        range_match = partition_range.match(line)
         if range_match:
             range_cols = [x.strip("` ") for x in range_match.group("cols").split(",")]
             log.debug(f"Partition range columns: {range_cols}")
 
-        member_match = partition_member.match(l)
+        member_match = partition_member.match(line)
         if member_match:
             part_name = member_match.group("name")
             part_vals_str = member_match.group("cols")
@@ -139,7 +139,7 @@ def _parse_partition_map(rows):
             )
             partitions.append(pos_part)
 
-        member_tail = partition_tail.match(l)
+        member_tail = partition_tail.match(line)
         if member_tail:
             if range_cols is None:
                 raise partitionmanager.types.TableInformationException(
@@ -200,7 +200,7 @@ def _split_partitions_around_position(partition_list, current_position):
         if not partitionmanager.types.is_partition_type(p):
             raise partitionmanager.types.UnexpectedPartitionException(p)
     if not isinstance(current_position, partitionmanager.types.Position):
-        raise ValueError()
+        raise ValueError
 
     less_than_partitions = list()
     greater_or_equal_partitions = list()
@@ -481,7 +481,7 @@ def _plan_partition_changes(
             "as without an empty partition to manipulate, you'll need to "
             "perform an expensive copy operation. See the bootstrap mode."
         )
-        raise partitionmanager.types.NoEmptyPartitionsAvailableException()
+        raise partitionmanager.types.NoEmptyPartitionsAvailableException
     if not active_partition:
         raise Exception("Active Partition can't be None")
 
@@ -626,8 +626,7 @@ def _should_run_changes(table, altered_partitions):
             log.debug(f"{p} is new")
             return True
 
-        if isinstance(p, partitionmanager.types.ChangePlannedPartition):
-            if p.important():
+        if isinstance(p, partitionmanager.types.ChangePlannedPartition) and p.important():
                 log.debug(f"{p} is marked important")
                 return True
     return False

--- a/partitionmanager/table_append_partition_test.py
+++ b/partitionmanager/table_append_partition_test.py
@@ -1,4 +1,4 @@
-# flake8: noqa: E501
+# ruff: noqa: E501
 
 import unittest
 import argparse
@@ -7,11 +7,8 @@ from partitionmanager.types import (
     ChangePlannedPartition,
     DatabaseCommand,
     DuplicatePartitionException,
-    MaxValuePartition,
-    MismatchedIdException,
     NewPlannedPartition,
     NoEmptyPartitionsAvailableException,
-    PositionPartition,
     InstantPartition,
     SqlInput,
     SqlQuery,
@@ -49,7 +46,7 @@ class MockDatabase(DatabaseCommand):
         self._response = []
         self._num_queries = 0
 
-    def run(self, cmd):
+    def run(self, cmd):  # noqa: ARG002
         self._num_queries += 1
         return self._response.pop()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,83 @@
+[tool.ruff]
+line-length = 99  # default is 88
+target-version = "py38"
+
+[tool.ruff.lint]
+select = [
+  "A",      # flake8-builtins
+  "AIR",    # Airflow
+  "ARG",    # flake8-unused-arguments
+  "ASYNC",  # flake8-async
+  "B",      # flake8-bugbear
+  "BLE",    # flake8-blind-except
+  "C90",    # McCabe cyclomatic complexity
+  "DJ",     # flake8-django
+  "E",      # pycodestyle
+  "EXE",    # flake8-executable
+  "F",      # Pyflakes
+  "FA",     # flake8-future-annotations
+  "FBT",    # flake8-boolean-trap
+  "FIX",    # flake8-fixme
+  "FLY",    # flynt
+  "ICN",    # flake8-import-conventions
+  "INP",    # flake8-no-pep420
+  "INT",    # flake8-gettext
+  "LOG",    # flake8-logging
+  "NPY",    # NumPy-specific rules
+  "PD",     # pandas-vet
+  "PERF",   # Perflint
+  "PGH",    # pygrep-hooks
+  "PIE",    # flake8-pie
+  "PL",     # Pylint
+  "PTH",    # flake8-use-pathlib
+  "PYI",    # flake8-pyi
+  "RET",    # flake8-return
+  "RSE",    # flake8-raise
+  "S",      # flake8-bandit
+  "SIM",    # flake8-simplify
+  "SLOT",   # flake8-slots
+  "T10",    # flake8-debugger
+  "TCH",    # flake8-type-checking
+  "TD",     # flake8-todos
+  "TID",    # flake8-tidy-imports
+  "TRIO",   # flake8-trio
+  "UP",     # pyupgrade
+  "W",      # pycodestyle
+  "YTT",    # flake8-2020
+  # "ANN",  # flake8-annotations
+  # "C4",   # flake8-comprehensions
+  # "COM",  # flake8-commas
+  # "CPY",  # flake8-copyright
+  # "D",    # pydocstyle
+  # "DTZ",  # flake8-datetimez
+  # "EM",   # flake8-errmsg
+  # "ERA",  # eradicate
+  # "FURB", # refurb
+  # "G",    # flake8-logging-format
+  # "I",    # isort
+  # "ISC",  # flake8-implicit-str-concat
+  # "N",    # pep8-naming
+  # "PT",   # flake8-pytest-style
+  # "Q",    # flake8-quotes
+  # "RUF",  # Ruff-specific rules
+  # "SLF",  # flake8-self
+  # "T20",  # flake8-print
+  # "TRY",  # tryceratops
+]
+ignore = ["S101"]  # Allow assert statements
+
+[tool.ruff.lint.mccabe]
+max-complexity = 16  # default is 10
+
+[tool.ruff.lint.per-file-ignores]
+"partitionmanager/cli.py" = ["B008"]  # TODO: Fix me
+"partitionmanager/cli_test.py" = ["S608", "SIM115", "SIM117"]  # TODO: Fix SIMs
+"partitionmanager/sql.py" = ["B904", "S603"]  # TODO: Fix S603
+"partitionmanager/table_append_partition.py" = ["S608", "SIM102"]  # TODO: Fix S608
+"partitionmanager/types.py" = ["B904", "RET505", "SLOT000"]  # TODO: Fix B904 and SLOT000
+"partitionmanager/types_test.py" = ["B015"]  # TODO: Fix me
+
+[tool.ruff.lint.pylint]
+max-args = 7  # default is 5
+max-branches = 15  # default is 12
+max-statements = 52  # default is 50


### PR DESCRIPTION
Fixes #70
* #70

After this `ruff lint` PR is merged we can have a followup PR to enable `ruff format` in pre-commit.  We should first decide if we want to keep `line-length` at 99 or the default of 88.
