### PR TITLE
Refactor `do_partition` to reduce the statement count

### DIFF
--- a/partitionmanager/cli.py
+++ b/partitionmanager/cli.py
@@ -369,8 +369,6 @@ def do_partition(conf):
         except partitionmanager.types.DatabaseCommandException as e:
             log.warning("Failed to automatically handle %s: %s", table, e)
             metrics.add("alter_errors", table.name, 1)
-        except partitionmanager.types.TableEmptyException:
-            log.warning("Table %s appears to be empty. Skipping.", table)
         except (ValueError, Exception) as e:
             log.warning("Failed to handle %s: %s", table, e)
             metrics.add("alter_errors", table.name, 1)

--- a/partitionmanager/cli.py
+++ b/partitionmanager/cli.py
@@ -274,16 +274,13 @@ MIGRATE_PARSER.add_argument(
 MIGRATE_PARSER.set_defaults(func=migrate_cmd)
 
 def _partition_table(conf, log, table, metrics):
-    table_problems = pm_tap.get_table_compatibility_problems(conf.dbcmd, table)
-    if table_problems:
+    if table_problems := pm_tap.get_table_compatibility_problems(conf.dbcmd, table):
         log.error(f"Cannot proceed: {table} {table_problems}")
         return None
 
     map_data = pm_tap.get_partition_map(conf.dbcmd, table)
 
-    duration = conf.partition_period
-    if table.partition_period:
-        duration = table.partition_period
+    duration = table.partition_period or conf.partition_period
 
     log.info(f"Evaluating {table} (duration={duration})")
     cur_pos = partitionmanager.database_helpers.get_position_of_table(

--- a/partitionmanager/cli.py
+++ b/partitionmanager/cli.py
@@ -356,8 +356,7 @@ def do_partition(conf):
     all_results = {}
     for table in conf.tables:
         try:
-            results = _partition_table(conf, log, table, metrics)
-            if results:
+            if results := _partition_table(conf, log, table, metrics):
                 all_results[table.name] = results
 
         except partitionmanager.types.NoEmptyPartitionsAvailableException:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ ignore = ["S101"]  # Allow assert statements
 max-complexity = 16  # default is 10
 
 [tool.ruff.lint.per-file-ignores]
-"partitionmanager/cli.py" = ["B008"]  # TODO: Fix me
+"partitionmanager/cli.py" = ["B008", "PERF203"]  # TODO: Fix B008, upgrade to Py3.11 for PERF203
 "partitionmanager/cli_test.py" = ["S608", "SIM115", "SIM117"]  # TODO: Fix SIMs
 "partitionmanager/sql.py" = ["B904", "S603"]  # TODO: Fix S603
 "partitionmanager/table_append_partition.py" = ["S608", "SIM102"]  # TODO: Fix S608

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,4 +116,3 @@ max-complexity = 16  # default is 10
 [tool.ruff.lint.pylint]
 max-args = 7  # default is 5
 max-branches = 15  # default is 12
-max-statements = 52  # default is 50


### PR DESCRIPTION
ruff complains about routines with more than 50 statements, and `do_partition` had 52. #80 bumped that to 54, and we can just do a little refactor to make it cleaner.

Removes `max-statements = 52 # default is 50` from the `pyproject.toml` since we no longer need the override.