### PR TITLE
Use timezone-aware datetimes -- ruff check --select=DTZ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Lint Python code with Ruff
       run: |
-        python -m ruff --output-format=github
+        python -m ruff check --output-format=github
 
     - name: Checking pyproject
       run: |

--- a/partitionmanager/cli.py
+++ b/partitionmanager/cli.py
@@ -346,7 +346,7 @@ def do_partition(conf):
                 continue
 
             log.info(f"{table} running SQL: {composite_sql_command}")
-            time_start = datetime.utcnow()
+            time_start = datetime.now(tz=timezone.utc)
             output = conf.dbcmd.run(composite_sql_command)
 
             all_results[table.name] = {"sql": composite_sql_command, "output": output}
@@ -364,7 +364,7 @@ def do_partition(conf):
             log.warning("Failed to handle %s: %s", table, e)
             metrics.add("alter_errors", table.name, 1)
 
-        time_end = datetime.utcnow()
+        time_end = datetime.now(tz=timezone.utc)
         if time_start:
             metrics.add(
                 "alter_time_seconds",

--- a/partitionmanager/cli_test.py
+++ b/partitionmanager/cli_test.py
@@ -348,7 +348,7 @@ partitionmanager:
         table_b:
         table_c:
 """,
-            datetime.now(),
+            datetime.now(tz=timezone.utc),
         )
         self.assertEqual(
             {str(x.name) for x in conf.tables}, set(["table_one", "table_two"])
@@ -364,7 +364,7 @@ partitionmanager:
     tables:
         one:
 """,
-            datetime.now(),
+            datetime.now(tz=timezone.utc),
         )
         self.assertEqual(conf.dbcmd.exe, "/usr/bin/true")
 
@@ -381,7 +381,7 @@ partitionmanager:
     tables:
         one:
 """,
-                datetime.now(),
+                datetime.now(tz=timezone.utc),
             )
 
     def test_migrate_cmd_out(self):

--- a/partitionmanager/database_helpers.py
+++ b/partitionmanager/database_helpers.py
@@ -48,9 +48,9 @@ def calculate_exact_timestamp_via_query(database, table, position_partition):
         position_partition.position,
     )
 
-    start = datetime.now()
+    start = datetime.now(tz=timezone.utc)
     exact_time_result = database.run(sql_select_cmd)
-    end = datetime.now()
+    end = datetime.now(tz=timezone.utc)
 
     if not len(exact_time_result) == 1:
         raise partitionmanager.types.NoExactTimeException("No exact timestamp result")

--- a/partitionmanager/migrate_test.py
+++ b/partitionmanager/migrate_test.py
@@ -1,7 +1,7 @@
 import io
 import unittest
 import yaml
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from .migrate import (
     _generate_sql_copy_commands,
@@ -60,7 +60,7 @@ class MockDatabase(DatabaseCommand):
 class TestBootstrapTool(unittest.TestCase):
     def test_writing_state_info(self):
         conf = Config()
-        conf.curtime = datetime(2021, 3, 1)
+        conf.curtime = datetime(2021, 3, 1, tzinfo=timezone.utc)
         conf.dbcmd = MockDatabase()
         conf.tables = [Table("test")]
 
@@ -97,7 +97,7 @@ class TestBootstrapTool(unittest.TestCase):
     def test_read_state_info(self):
         self.maxDiff = None
         conf_past = Config()
-        conf_past.curtime = datetime(2021, 3, 1)
+        conf_past.curtime = datetime(2021, 3, 1, tzinfo=timezone.utc)
         conf_past.dbcmd = MockDatabase()
         conf_past.tables = [Table("test").set_partition_period(timedelta(days=30))]
 
@@ -109,7 +109,7 @@ class TestBootstrapTool(unittest.TestCase):
             calculate_sql_alters_from_state_info(conf_past, state_fs)
 
         conf_now = Config()
-        conf_now.curtime = datetime(2021, 3, 3)
+        conf_now.curtime = datetime(2021, 3, 3, tzinfo=timezone.utc)
         conf_now.dbcmd = MockDatabase()
         conf_now.dbcmd._response = [
             [
@@ -153,7 +153,7 @@ class TestBootstrapTool(unittest.TestCase):
         self.maxDiff = None
         conf = Config()
         conf.assume_partitioned_on = ["orderID", "authzID"]
-        conf.curtime = datetime(2021, 3, 3)
+        conf.curtime = datetime(2021, 3, 3, tzinfo=timezone.utc)
         conf.dbcmd = MockDatabase()
         conf.dbcmd._select_response = [[{"authzID": 22}], [{"orderID": 11}]]
         conf.dbcmd._response = [
@@ -223,7 +223,7 @@ class TestBootstrapTool(unittest.TestCase):
     def test_generate_sql_copy_commands(self):
         conf = Config()
         conf.assume_partitioned_on = ["id"]
-        conf.curtime = datetime(2021, 3, 3)
+        conf.curtime = datetime(2021, 3, 3, tzinfo=timezone.utc)
         conf.dbcmd = MockDatabase()
         map_data = _override_config_to_map_data(conf)
         cmds = list(
@@ -263,7 +263,7 @@ class TestBootstrapTool(unittest.TestCase):
 
     def test_plan_partitions_for_time_offsets(self):
         parts = _plan_partitions_for_time_offsets(
-            datetime(2021, 3, 3),
+            datetime(2021, 3, 3, tzinfo=timezone.utc),
             [timedelta(days=60), timedelta(days=360)],
             [11943234],
             [16753227640],

--- a/partitionmanager/table_append_partition_test.py
+++ b/partitionmanager/table_append_partition_test.py
@@ -462,7 +462,7 @@ class TestPartitionAlgorithm(unittest.TestCase):
         )
 
     def test_predict_forward_time(self):
-        t = datetime(2000, 1, 1)
+        t = datetime(2000, 1, 1, tzinfo=timezone.utc)
 
         with self.assertRaises(ValueError):
             _predict_forward_time(mkPos(0, 0), mkPos(100), [100], t)

--- a/partitionmanager/types_test.py
+++ b/partitionmanager/types_test.py
@@ -205,12 +205,12 @@ class TestTypes(unittest.TestCase):
             PositionPartition("p_20210101").set_position([1, 2, 3, 4])
         )
         self.assertFalse(c.has_modifications)
-        c.set_timestamp(datetime(2021, 1, 2))
+        c.set_timestamp(datetime(2021, 1, 2, tzinfo=timezone.utc))
         y = c.set_position([10, 10, 10, 10])
         self.assertEqual(c, y)
         self.assertTrue(c.has_modifications)
 
-        self.assertEqual(c.timestamp(), datetime(2021, 1, 2))
+        self.assertEqual(c.timestamp(), datetime(2021, 1, 2, tzinfo=timezone.utc))
         self.assertEqual(c.position.as_list(), [10, 10, 10, 10])
 
         self.assertEqual(
@@ -276,7 +276,7 @@ class TestTypes(unittest.TestCase):
             .as_partition(),
             NewPlannedPartition()
             .set_columns(4)
-            .set_timestamp(datetime(2021, 1, 1))
+            .set_timestamp(datetime(2021, 1, 1, tzinfo=timezone.utc))
             .as_partition(),
         )
 
@@ -287,7 +287,7 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(
             NewPlannedPartition()
             .set_columns(5)
-            .set_timestamp(datetime(2021, 12, 31, hour=23, minute=15))
+            .set_timestamp(datetime(2021, 12, 31, hour=23, minute=15, tzinfo=timezone.utc))
             .as_partition(),
             MaxValuePartition("p_20211231", count=5),
         )
@@ -297,7 +297,7 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(
             NewPlannedPartition()
             .set_position([3])
-            .set_timestamp(datetime(2021, 12, 31))
+            .set_timestamp(datetime(2021, 12, 31, tzinfo=timezone.utc))
             .as_partition(),
             PositionPartition("p_20211231").set_position(mkPos(3)),
         )
@@ -305,7 +305,7 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(
             NewPlannedPartition()
             .set_position([1, 1, 1])
-            .set_timestamp(datetime(1994, 1, 1))
+            .set_timestamp(datetime(1994, 1, 1, tzinfo=timezone.utc))
             .as_partition(),
             PositionPartition("p_19940101").set_position([1, 1, 1]),
         )
@@ -313,18 +313,18 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(
             NewPlannedPartition()
             .set_position([3])
-            .set_timestamp(datetime(2021, 12, 31)),
+            .set_timestamp(datetime(2021, 12, 31, tzinfo=timezone.utc)),
             NewPlannedPartition()
             .set_position([3])
-            .set_timestamp(datetime(2021, 12, 31)),
+            .set_timestamp(datetime(2021, 12, 31, tzinfo=timezone.utc)),
         )
 
         self.assertEqual(
             NewPlannedPartition()
             .set_position([99, 999])
-            .set_timestamp(datetime(2021, 12, 31, hour=19, minute=2))
+            .set_timestamp(datetime(2021, 12, 31, hour=19, minute=2, tzinfo=timezone.utc))
             .set_as_max_value(),
-            NewPlannedPartition().set_columns(2).set_timestamp(datetime(2021, 12, 31)),
+            NewPlannedPartition().set_columns(2).set_timestamp(datetime(2021, 12, 31, tzinfo=timezone.utc)),
         )
 
 
@@ -380,7 +380,7 @@ class TestPartition(unittest.TestCase):
         self.assertLess(cur_pos, p_20230724)
 
     def test_instant_partition(self):
-        now = datetime.utcnow()
+        now = datetime.now(tz=timezone.utc)
 
         ip = InstantPartition("p_20380101", now, [1, 2])
         self.assertEqual(ip.position.as_list(), [1, 2])
@@ -390,7 +390,7 @@ class TestPartition(unittest.TestCase):
     def test_is_partition_type(self):
         self.assertTrue(is_partition_type(mkPPart("b", 1, 2)))
         self.assertTrue(
-            is_partition_type(InstantPartition("p_19490520", datetime.utcnow(), [1, 2]))
+            is_partition_type(InstantPartition("p_19490520", datetime.now(tz=timezone.utc), [1, 2]))
         )
         self.assertFalse(is_partition_type(None))
         self.assertFalse(is_partition_type(1))

--- a/partitionmanager/types_test.py
+++ b/partitionmanager/types_test.py
@@ -287,7 +287,9 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(
             NewPlannedPartition()
             .set_columns(5)
-            .set_timestamp(datetime(2021, 12, 31, hour=23, minute=15, tzinfo=timezone.utc))
+            .set_timestamp(
+                datetime(2021, 12, 31, hour=23, minute=15, tzinfo=timezone.utc)
+            )
             .as_partition(),
             MaxValuePartition("p_20211231", count=5),
         )
@@ -322,9 +324,13 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(
             NewPlannedPartition()
             .set_position([99, 999])
-            .set_timestamp(datetime(2021, 12, 31, hour=19, minute=2, tzinfo=timezone.utc))
+            .set_timestamp(
+                datetime(2021, 12, 31, hour=19, minute=2, tzinfo=timezone.utc)
+            )
             .set_as_max_value(),
-            NewPlannedPartition().set_columns(2).set_timestamp(datetime(2021, 12, 31, tzinfo=timezone.utc)),
+            NewPlannedPartition()
+            .set_columns(2)
+            .set_timestamp(datetime(2021, 12, 31, tzinfo=timezone.utc)),
         )
 
 
@@ -390,7 +396,9 @@ class TestPartition(unittest.TestCase):
     def test_is_partition_type(self):
         self.assertTrue(is_partition_type(mkPPart("b", 1, 2)))
         self.assertTrue(
-            is_partition_type(InstantPartition("p_19490520", datetime.now(tz=timezone.utc), [1, 2]))
+            is_partition_type(
+                InstantPartition("p_19490520", datetime.now(tz=timezone.utc), [1, 2])
+            )
         )
         self.assertFalse(is_partition_type(None))
         self.assertFalse(is_partition_type(1))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ select = [
   "BLE",    # flake8-blind-except
   "C90",    # McCabe cyclomatic complexity
   "DJ",     # flake8-django
+  "DTZ",    # flake8-datetimez
   "E",      # pycodestyle
   "EXE",    # flake8-executable
   "F",      # Pyflakes
@@ -85,7 +86,6 @@ select = [
   # "COM",  # flake8-commas
   # "CPY",  # flake8-copyright
   # "D",    # pydocstyle
-  # "DTZ",  # flake8-datetimez
   # "EM",   # flake8-errmsg
   # "ERA",  # eradicate
   # "FURB", # refurb


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/#flake8-datetimez-dtz

% `ruff check --select=DTZ --statistics`
```
17	DTZ001	The use of `datetime.datetime()` without `tzinfo` argument is not allowed
 5	DTZ005	The use of `datetime.datetime.now()` without `tz` argument is not allowed
 4	DTZ003	The use of `datetime.datetime.utcnow()` is not allowed, use `datetime.datetime.now(tz=)` instead
```
% `ruff rule DTZ001`
# call-datetime-without-tzinfo (DTZ001)

Derived from the **flake8-datetimez** linter.

## What it does
Checks for `datetime` instantiations that lack a `tzinfo` argument.

## Why is this bad?
`datetime` objects are "naive" by default, in that they do not include
timezone information. "Naive" objects are easy to understand, but ignore
some aspects of reality, which can lead to subtle bugs. Timezone-aware
`datetime` objects are preferred, as they represent a specific moment in
time, unlike "naive" objects.

By providing a `tzinfo` value, a `datetime` can be made timezone-aware.

## Example
```python
import datetime

datetime.datetime(2000, 1, 1, 0, 0, 0)
```

Use instead:
```python
import datetime

datetime.datetime(2000, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
```

Or, for Python 3.11 and later:
```python
import datetime

datetime.datetime(2000, 1, 1, 0, 0, 0, tzinfo=datetime.UTC)
```
